### PR TITLE
Supporting simulation for cordova-plugin-network-information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Calling `simulate()` will launch your app in the browser, and open a second brow
 
 This preview version currently includes built-in support for the following Cordova plugins:
 
+* [cordova-plugin-battery-status](https://github.com/apache/cordova-plugin-battery-status)
 * [cordova-plugin-camera](https://github.com/apache/cordova-plugin-camera)
 * [cordova-plugin-console](https://github.com/apache/cordova-plugin-console)
 * [cordova-plugin-contacts](https://github.com/apache/cordova-plugin-contacts)
@@ -51,6 +52,7 @@ This preview version currently includes built-in support for the following Cordo
 * [cordova-plugin-geolocation](https://github.com/apache/cordova-plugin-geolocation)
 * [cordova-plugin-globalization](https://github.com/apache/cordova-plugin-globalization)
 * [cordova-plugin-media](https://github.com/apache/cordova-plugin-media)
+* [cordova-plugin-network-information](https://github.com/apache/cordova-plugin-network-information)
 * [cordova-plugin-vibration](https://github.com/apache/cordova-plugin-vibration)
 
 ## Adding simulation support to plugins

--- a/src/platforms/windows/app-host-clobbers.js
+++ b/src/platforms/windows/app-host-clobbers.js
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
+/*
+ * Windows API definition taken from:
+ * - https://msdn.microsoft.com/library/windows/apps/windows.networking.connectivity.networkconnectivitylevel.aspx
+ */
+
 module.exports = {
     // Сlobbing WinJS.Application.addEventListener
     // for proper cordova-plugin-test-framework initialization
@@ -7,6 +12,18 @@ module.exports = {
     WinJS: {
         Application: {
             addEventListener: function () {}
+        }
+    },
+    Windows: {
+        Networking: {
+            Connectivity: {
+                NetworkConnectivityLevel: {
+                    none: 0,
+                    localAccess: 1,
+                    constrainedInternetAccess: 2,
+                    internetAccess: 3
+                }
+            }
         }
     }
 };

--- a/src/plugins/cordova-plugin-network-information/app-host-clobbers.js
+++ b/src/plugins/cordova-plugin-network-information/app-host-clobbers.js
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+module.exports = {
+    Windows: {
+        Networking: {
+            Connectivity: {
+                NetworkInformation: {
+                    getInternetConnectionProfile: function () {
+                        return {
+                            getNetworkConnectivityLevel: function () {
+                                // defined in platforms/windows/app-host-clobbers.js
+                                return Windows.Networking.Connectivity.NetworkConnectivityLevel.internetAccess;
+                            },
+                            networkAdapter: {
+                                ianaInterfaceType: 71
+                            }
+                        };
+                    }
+                },
+                NetworkCostType: {},
+                NetworkAuthenticationType: {},
+                NetworkEncryptionType: {}
+            }
+        }
+    }
+};

--- a/src/plugins/cordova-plugin-network-information/network.js
+++ b/src/plugins/cordova-plugin-network-information/network.js
@@ -6,7 +6,7 @@
 var db = require('db');
 
 var simConstants = {
-    NETWORK_TYPE_KEY: 'network-key'
+    NETWORK_TYPE: 'network-type'
 };
 
 var network = {
@@ -21,14 +21,11 @@ var network = {
         NONE: 'none'
     },
 
-    _defaultConnectionType: this.ConnectionTypes.CELL_4G,
-
     connectionType: null,
-
     successCallback: null,
 
     initialize: function () {
-        this.connectionType = db.retrieve(simConstants.NETWORK_TYPE_KEY) || this._defaultConnectionType;
+        this.connectionType = db.retrieve(simConstants.NETWORK_TYPE) || this.ConnectionTypes.CELL_4G;
     },
 
     /**
@@ -37,15 +34,14 @@ var network = {
     updateNetworkType: function (type) {
         this.connectionType = type;
 
-        db.save(simConstants.NETWORK_TYPE_KEY, this.connectionType);
+        db.save(simConstants.NETWORK_TYPE, this.connectionType);
 
         this.sendUpdate();
     },
 
     sendUpdate: function () {
         if (typeof this.successCallback === 'function') {
-            var value = this.ConnectionTypes[this.connectionType];
-            this.successCallback(value);
+            this.successCallback(this.connectionType);
         }
     }
 };

--- a/src/plugins/cordova-plugin-network-information/network.js
+++ b/src/plugins/cordova-plugin-network-information/network.js
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+// Connection types from Apache Cordova network-information plugin's Connection.js implementation.
+// See https://github.com/apache/cordova-plugin-network-information/blob/master/www/Connection.js
+
+var db = require('db');
+
+var simConstants = {
+    NETWORK_TYPE_KEY: 'network-key'
+};
+
+var network = {
+    ConnectionTypes: {
+        UNKNOWN: 'unknown',
+        ETHERNET: 'ethernet',
+        WIFI: 'wifi',
+        CELL_2G: '2g',
+        CELL_3G: '3g',
+        CELL_4G: '4g',
+        CELL: 'cellular',
+        NONE: 'none'
+    },
+
+    _defaultConnectionType: this.ConnectionTypes.CELL_4G,
+
+    connectionType: null,
+
+    successCallback: null,
+
+    initialize: function () {
+        this.connectionType = db.retrieve(simConstants.NETWORK_TYPE_KEY) || this._defaultConnectionType;
+    },
+
+    /**
+     * @param {string} type
+     */
+    updateNetworkType: function (type) {
+        this.connectionType = type;
+
+        db.save(simConstants.NETWORK_TYPE_KEY, this.connectionType);
+
+        this.sendUpdate();
+    },
+
+    sendUpdate: function () {
+        if (typeof this.successCallback === 'function') {
+            var value = this.ConnectionTypes[this.connectionType];
+            this.successCallback(value);
+        }
+    }
+};
+
+module.exports = network;

--- a/src/plugins/cordova-plugin-network-information/sim-host-handlers.js
+++ b/src/plugins/cordova-plugin-network-information/sim-host-handlers.js
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+module.exports = function (message) {
+
+    var network = require('./network');
+
+    function getConnectionInfo(success, fail) {
+        if (typeof success === 'function') {
+            network.successCallback = success;
+            network.sendUpdate();
+        }
+    }
+
+    return {
+        'NetworkStatus': {
+            'getConnectionInfo': function (success, fail, args) {
+                getConnectionInfo(success);
+            }
+        }
+    };
+};

--- a/src/plugins/cordova-plugin-network-information/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-network-information/sim-host-panels.html
@@ -1,0 +1,5 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+
+<cordova-panel id="network-information" caption="Network Connection">
+    <cordova-combo id="connection-list" label="Connection type"></cordova-combo>
+</cordova-panel>

--- a/src/plugins/cordova-plugin-network-information/sim-host.js
+++ b/src/plugins/cordova-plugin-network-information/sim-host.js
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+var network = require('./network');
+
+network.initialize();
+
+function initialize() {
+    var connectionTypeList = document.getElementById('connection-list'),
+        type,
+        option;
+
+    for (type in network.ConnectionTypes) {
+        if (network.ConnectionTypes.hasOwnProperty(type)) {
+            option = document.createElement('option');
+            option.appendChild(document.createTextNode(type));
+            option.value = type;
+
+            if (type === network.connectionType) {
+                option.selected = true;
+            }
+
+            connectionTypeList.appendChild(option);
+        }
+    }
+
+    connectionTypeList.addEventListener('change', function () {
+        network.updateNetworkType(connectionTypeList.value);
+    });
+}
+
+module.exports = {
+    initialize: initialize
+};

--- a/src/plugins/cordova-plugin-network-information/sim-host.js
+++ b/src/plugins/cordova-plugin-network-information/sim-host.js
@@ -6,16 +6,20 @@ network.initialize();
 
 function initialize() {
     var connectionTypeList = document.getElementById('connection-list'),
-        type,
-        option;
+        ConnectionTypes = network.ConnectionTypes,
+        key,
+        option,
+        connection;
 
-    for (type in network.ConnectionTypes) {
-        if (network.ConnectionTypes.hasOwnProperty(type)) {
+    for (key in ConnectionTypes) {
+        if (ConnectionTypes.hasOwnProperty(key)) {
+            connection = ConnectionTypes[key];
+
             option = document.createElement('option');
-            option.appendChild(document.createTextNode(type));
-            option.value = type;
+            option.appendChild(document.createTextNode(connection));
+            option.value = connection;
 
-            if (type === network.connectionType) {
+            if (connection === network.connectionType) {
                 option.selected = true;
             }
 


### PR DESCRIPTION
Hi @TimBarham ! I've implemented the simulation for the network-information plugin.
I'm running the automated test suite of the cordova mobilespec app, with taco-simulate, and it the results are really good, I'm implementing the support of the missing plugins based on the automated test suite results and manual test using the mobilespec app.

platform: iOS
![mobilespec-network-plugin](https://cloud.githubusercontent.com/assets/2309921/13694265/6b3e010e-e732-11e5-89ad-aef62d61fd19.png)

Thanks!