### PR TITLE
Fixed livereload defaulting to false when cordova-simulate was used via API

### DIFF
--- a/src/simulate.js
+++ b/src/simulate.js
@@ -28,7 +28,7 @@ var launchServer = function (opts) {
     config.platform = platform;
     config.simHostOptions = simHostOpts;
     config.telemetry = opts.telemetry;
-    config.liveReload = !!opts.livereload;
+    config.liveReload = opts.hasOwnProperty('livereload') ? !!opts.livereload : true;
     config.forcePrepare = !!opts.forceprepare;
     config.xhrProxy = !!opts.corsproxy;
 


### PR DESCRIPTION
This is to fix a bug in my previous changes. Right now, live reload defaults to disabled if cordova-simulate is used programmatically. The intended behavior is for live reload to default to true.

Note that for command-line usage, live reload is correctly defaulting to true already because of the argument parsing logic in `bin/simulate`.