### PR TITLE
Adding touch events support in app-host

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Where opts is an object with the following properties (all optional):
 * **livereload** - A boolean. Set to false to disable live reload. Defaults to true.
 * **forceprepare** - A boolean. Set to true to force a `cordova prepare` whenever a file changes during live reload. If this is false, the server attempts to simply copy the changed file to the platform rather than doing a `cordova prepare`. Ignored if live reload is disabled. Defaults to false.
 * **corsproxy** - Boolean indicating if XMLHttpRequest is proxied through the simulate server. This is useful for working around CORS issues at development time. Defaults to true.
+* **touchevents** - A boolean. Set to false to disable the simulaton of touch events in App-Host. Defaults to true.
 
 
 # What it does

--- a/src/app-host/app-host.js
+++ b/src/app-host/app-host.js
@@ -84,7 +84,11 @@ socket.on('init-telemetry', function (data) {
 });
 
 socket.on('init-xhr-proxy', function (data) {
-    require('xhr-proxy').init(); 
+    require('xhr-proxy').init();
+});
+
+socket.on('init-touch-events', function (data) {
+    require('./touch-events').init();
 });
 
 socket.emit('register-app-host');

--- a/src/app-host/touch-events.js
+++ b/src/app-host/touch-events.js
@@ -56,11 +56,13 @@ function _simulateTouchEvent(type, mouseevent) {
     eventData.changedTouches.item = itemFn;
     eventData.targetTouches.item = itemFn;
 
-    var simulatedEvent = _createTouchEvent(type, true, true, eventData);
+    var listenerName = 'on' + type,
+        simulatedEvent = _createTouchEvent(type, true, true, eventData);
+
     mouseevent.target.dispatchEvent(simulatedEvent);
 
-    if (typeof mouseevent.target['on' + type] === 'function') {
-        mouseevent.target['on' + type].apply(mouseevent.target, [simulatedEvent]);
+    if (typeof mouseevent.target[listenerName] === 'function') {
+        mouseevent.target[listenerName].apply(mouseevent.target, [simulatedEvent]);
     }
 }
 

--- a/src/app-host/touch-events.js
+++ b/src/app-host/touch-events.js
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Based in part on code from Apache Ripple, https://github.com/apache/incubator-ripple
+
+var utils = require('utils');
+
+var _lastMouseEvent,
+    _isMouseDown;
+
+// NOTE: missing view, detail, touches, targetTouches, scale and rotation
+function _createTouchEvent(type, canBubble, cancelable, eventData) {
+    var touchEvent = window.document.createEvent('Event');
+    touchEvent.initEvent(type, canBubble, cancelable);
+    utils.mixin(eventData, touchEvent);
+
+    return touchEvent;
+}
+
+function _simulateTouchEvent(type, mouseevent) {
+    if (_lastMouseEvent &&
+            mouseevent.type === _lastMouseEvent.type &&
+            mouseevent.pageX === _lastMouseEvent.pageX &&
+            mouseevent.pageY === _lastMouseEvent.pageY) {
+        return;
+    }
+
+    _lastMouseEvent = mouseevent;
+
+    var touchObj = {
+        clientX: mouseevent.pageX,
+        clientY: mouseevent.pageY,
+        pageX: mouseevent.pageX,
+        pageY: mouseevent.pageY,
+        screenX: mouseevent.pageX,
+        screenY: mouseevent.pageY,
+        target: mouseevent.target,
+        identifier: ''
+    };
+
+    var eventData = {
+        altKey: mouseevent.altKey,
+        ctrlKey: mouseevent.ctrlKey,
+        shiftKey: mouseevent.shiftKey,
+        metaKey: mouseevent.metaKey,
+        changedTouches: [touchObj],
+        targetTouches: type === 'touchend' ? [] : [touchObj],
+        touches: type === 'touchend' ? [] : [touchObj]
+    };
+
+    utils.mixin(touchObj, eventData);
+
+    var itemFn = function (index) {
+        return this[index];
+    };
+
+    eventData.touches.item = itemFn;
+    eventData.changedTouches.item = itemFn;
+    eventData.targetTouches.item = itemFn;
+
+    var simulatedEvent = _createTouchEvent(type, true, true, eventData);
+    mouseevent.target.dispatchEvent(simulatedEvent);
+
+    if (typeof mouseevent.target['on' + type] === 'function') {
+        mouseevent.target['on' + type].apply(mouseevent.target, [simulatedEvent]);
+    }
+}
+
+function init() {
+    window.document.addEventListener('mousedown', function (event) {
+        _isMouseDown = true;
+        _simulateTouchEvent('touchstart', event);
+    }, true);
+
+    window.document.addEventListener('mousemove', function (event) {
+        if (_isMouseDown) {
+            _simulateTouchEvent('touchmove', event);
+        }
+    }, true);
+
+    window.document.addEventListener('mouseup', function (event) {
+        _isMouseDown = false;
+        _simulateTouchEvent('touchend', event);
+    }, true);
+
+    window.Node.prototype.ontouchstart = null;
+    window.Node.prototype.ontouchend = null;
+    window.Node.prototype.ontouchmove = null;
+}
+
+module.exports.init = init;

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -101,6 +101,14 @@ self = module.exports = {
         });
     },
 
+    mixin: function (mixin, to) {
+        for (var prop in mixin) {
+            if (Object.hasOwnProperty.call(mixin, prop)) {
+                to[prop] = mixin[prop];
+            }
+        }
+    },
+
     copy: function (obj) {
         var i,
             newObj = Array.isArray(obj) ? [] : {};
@@ -258,4 +266,3 @@ function createUUIDPart(length) {
     }
     return uuidpart;
 }
-

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -6,71 +6,30 @@ var fs = require('fs'),
 var config = {};
 var simulationFilePath;
 
+// module properties
+[
+    'liveReload',
+    'platform',
+    'platformRoot',
+    'forcePrepare',
+    'projectRoot',
+    'server',
+    'telemetry',
+    'simHostOptions',
+    'xhrProxy',
+    'touchEvents'
+].forEach(function (prop) {
+    Object.defineProperty(module.exports, prop, {
+        get: function () {
+            return getValue(prop);
+        },
+        set: function (value) {
+            setValue(prop, value);
+        }
+    });
+});
+
 Object.defineProperties(module.exports, {
-    liveReload: {
-        get: function () {
-            return getValue('liveReload');
-        },
-        set: function (value) {
-            setValue('liveReload', value);
-        }
-    },
-    platform: {
-        get: function () {
-            return getValue('platform');
-        },
-        set: function (value) {
-            setValue('platform', value);
-        }
-    },
-    platformRoot: {
-        get: function () {
-            return getValue('platformRoot');
-        },
-        set: function (value) {
-            setValue('platformRoot', value);
-        }
-    },
-    forcePrepare: {
-        get: function () {
-            return getValue('forcePrepare');
-        },
-        set: function (value) {
-            setValue('forcePrepare', value);
-        }
-    },
-    projectRoot: {
-        get: function () {
-            return getValue('projectRoot');
-        },
-        set: function (value) {
-            setValue('projectRoot', value, true)
-        }
-    },
-    server: {
-        get: function () {
-            return getValue('server', true);
-        },
-        set: function (value) {
-            setValue('server', value);
-        }
-    },
-    telemetry: {
-        get: function () {
-            return getValue('telemetry', true);
-        },
-        set: function (value) {
-            setValue('telemetry', value);
-        }
-    },
-    simHostOptions: {
-        get: function () {
-            return getValue('simHostOptions');
-        },
-        set: function (value) {
-            setValue('simHostOptions', value);
-        }
-    },
     simulationFilePath: {
         get: function () {
             if (!simulationFilePath) {
@@ -81,14 +40,6 @@ Object.defineProperties(module.exports, {
                 }
             }
             return simulationFilePath;
-        }
-    },
-    xhrProxy: {
-        get: function() {
-            return getValue('xhrProxy', true);
-        },
-        set: function(value) {
-            setValue('xhrProxy', value);
         }
     }
 });

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -8,23 +8,23 @@ var simulationFilePath;
 
 // module properties
 [
-    'liveReload',
-    'platform',
-    'platformRoot',
-    'forcePrepare',
-    'projectRoot',
-    'server',
-    'telemetry',
-    'simHostOptions',
-    'xhrProxy',
-    'touchEvents'
+    { name: 'liveReload'},
+    { name: 'platform' },
+    { name: 'platformRoot' },
+    { name: 'forcePrepare' },
+    { name: 'projectRoot', single: true },
+    { name: 'server', optional: true },
+    { name: 'telemetry', optional: true },
+    { name: 'xhrProxy', optional: true },
+    { name: 'simHostOptions' },
+    { name: 'touchEvents', optional: true }
 ].forEach(function (prop) {
-    Object.defineProperty(module.exports, prop, {
+    Object.defineProperty(module.exports, prop.name, {
         get: function () {
-            return getValue(prop);
+            return getValue(prop.name, prop.optional);
         },
         set: function (value) {
-            setValue(prop, value);
+            setValue(prop.name, value, prop.single);
         }
     });
 });

--- a/src/server/socket.js
+++ b/src/server/socket.js
@@ -50,10 +50,15 @@ function init(server) {
             if (config.telemetry) {
                 socket.emit('init-telemetry');
             }
-            
+
             // Set up xhr proxy
             if (config.xhrProxy) {
                 socket.emit('init-xhr-proxy');
+            }
+
+            // setup touch events support
+            if (config.touchEvents) {
+                socket.emit('init-touch-events');
             }
 
             handlePendingEmits(appHost);

--- a/src/simulate.js
+++ b/src/simulate.js
@@ -30,14 +30,15 @@ var launchServer = function (opts) {
     config.telemetry = opts.telemetry;
     config.liveReload = opts.hasOwnProperty('livereload') ? !!opts.livereload : true;
     config.forcePrepare = !!opts.forceprepare;
-    config.xhrProxy = !!opts.corsproxy;
+    config.xhrProxy = opts.hasOwnProperty('corsproxy') ? !!opts.corsproxy : true;
+    config.touchEvents = opts.hasOwnProperty('touchevents') ? !!opts.touchevents : true;
 
     /* attach simulation host middleware */
     var middlewarePath = path.join(simHostOpts.simHostRoot, 'server', 'server');
     if (fs.existsSync(middlewarePath + '.js')) {
         require(middlewarePath).attach(server.app, dirs);
     }
-    
+
     /* attach CORS proxy middleware */
     if (!!opts.corsproxy) {
         require('./server/xhr-proxy').attach(server.app);


### PR DESCRIPTION
In this PR I've added the support of touch events in app-host. This follows the approach of other configurable functionality, it can be disabled. The implementation is based on Ripple implementation of touch events support.

I've also do a minor refactoring to the config module. Now we have more properties than before, and only one of them has a different setter, so I've changed the way we add properties to the module.export object that is done automatically for most of the properties. I'm open to your feedback about it :)

There's an inconsistency between the documentation about `corsproxy` default value and what it actually does, so I've fixed it to the default value specified in the README.md. @dlebu I can change it back and update the documentation if you think that the default value should be different.

Thanks!