### PR TITLE
CoreAndroid.backHistory app-host implementation and minor fixes.

### DIFF
--- a/src/app-host/live-reload-client.js
+++ b/src/app-host/live-reload-client.js
@@ -7,7 +7,7 @@ var liveReloadEvents = {
     CAN_REFRESH: 'lr-can-refresh',
     REFRESH_FILE: 'lr-refresh-file',
     FULL_RELOAD: 'lr-full-reload'
-}
+};
 
 var URL_ATTRIB_NAME = 'url';
 var HREF_ATTRIB_NAME = 'href';
@@ -19,7 +19,6 @@ var referenceAttributes = [
 ];
 
 module.exports.start = function (sock) {
-    var head = document.getElementsByTagName('head')[0];
     var serverUrl = window.location.protocol + '//' + window.location.host;
     var localUrlPrefixes = [
         serverUrl,
@@ -28,7 +27,6 @@ module.exports.start = function (sock) {
         ''
     ];
     var pendingFilesToRefresh = {};
-    var stylesheets;
     var socket = sock;
 
     /**
@@ -80,7 +78,7 @@ module.exports.start = function (sock) {
     }
 
     /**
-     * Finds all the DOM elements that have a reference attribute ("url", "href" or "src") pointing to the given relative path. Excludes <script> tags. 
+     * Finds all the DOM elements that have a reference attribute ("url", "href" or "src") pointing to the given relative path. Excludes <script> tags.
      *
      * @param {String} fileRelativePath The URL of the file to check, relative to the webRoot.
      * @returns {{ domNode: Element, referenceAttribute: string }[]} An array of "resources" referencing the given file.

--- a/src/modules/event.js
+++ b/src/modules/event.js
@@ -7,7 +7,7 @@ var utils = require('utils'),
 
 function _on(eventType, listener, scope, once) {
     if (!eventType) {
-        throw "eventType must be truthy";
+        throw 'eventType must be truthy';
     }
     _listeners[eventType] = _listeners[eventType] || [];
     _listeners[eventType].push({

--- a/src/modules/xhr-proxy.js
+++ b/src/modules/xhr-proxy.js
@@ -15,7 +15,7 @@ var isSameOriginRequest = function (url) {
 };
 
 var parseUrl = function (url) {
-    var a = document.createElement("a");
+    var a = document.createElement('a');
 
     a.href = url;
 
@@ -42,7 +42,7 @@ var init = function () {
             var sameOrigin = isSameOriginRequest(url);
 
             if (!sameOrigin) {
-                url = "/xhr_proxy?rurl=" + escape(url);
+                url = '/xhr_proxy?rurl=' + escape(url);
             }
 
             origMethods.open.apply(xhr, Array.prototype.slice.call(arguments));
@@ -54,4 +54,4 @@ var init = function () {
 
 module.exports = {
     init: init
-}
+};

--- a/src/platforms/android/app-host-handlers.js
+++ b/src/platforms/android/app-host-handlers.js
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+module.exports = {
+    'CoreAndroid': {
+        'backHistory': function (success, fail, service, action, args) {
+            window.history.go(-1);
+            success && success();
+        }
+    }
+};

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -44,7 +44,7 @@ Object.defineProperties(module.exports, {
             return getValue('projectRoot');
         },
         set: function (value) {
-            setValue('projectRoot', value, true)
+            setValue('projectRoot', value, true);
         }
     },
     server: {

--- a/src/server/live-reload/live-reload-server.js
+++ b/src/server/live-reload/live-reload-server.js
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 var config = require('../config');
-var fs = require('fs');
 var ncp = require('ncp');
 var path = require('path');
 var prepare = require('../prepare');
@@ -13,7 +12,7 @@ var liveReloadEvents = {
     CAN_REFRESH: 'lr-can-refresh',
     REFRESH_FILE: 'lr-refresh-file',
     FULL_RELOAD: 'lr-full-reload'
-}
+};
 
 var socket;
 var watcher;
@@ -104,4 +103,4 @@ module.exports.stop = function () {
     if (watcher) {
         watcher.stopWatching();
     }
-}
+};

--- a/src/server/live-reload/watcher.js
+++ b/src/server/live-reload/watcher.js
@@ -4,7 +4,6 @@ var config = require('../config');
 var fs = require('fs');
 var log = require('../log');
 var path = require('path');
-var Q = require('q');
 
 var EVENT_IGNORE_DURATION = 150;
 var WWW_ROOT = 'www';
@@ -36,7 +35,7 @@ Watcher.prototype.stopWatching = function () {
         this.mergesWatcher.close();
         this.mergesWatcher = null;
     }
-}
+};
 
 function handleWwwWatcherEvent(event, fileRelativePath) {
     handleWatcherEvent.bind(this)(WWW_ROOT, fileRelativePath);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 var fs = require('fs'),
-    http = require('http'),
     path = require('path'),
     replaceStream = require('replacestream'),
     cordovaServe = require('cordova-serve'),
-    Q = require('q'),
     send = require('send'),
     url = require('url'),
     config = require('./config'),
@@ -31,7 +29,7 @@ function attach(app) {
     app.use(plugins.getRouter());
     app.use('/simulator', cordovaServe.static(dirs.hostRoot['sim-host']));
     app.use('/simulator/thirdparty', cordovaServe.static(dirs.thirdParty));
-    
+
 }
 
 function sendHostJsFile(response, hostType) {

--- a/src/server/sim-files.js
+++ b/src/server/sim-files.js
@@ -57,7 +57,7 @@ function waitOnAppHostJs() {
 var appHostJsPromise;
 function createAppHostJsFile() {
     appHostJsPromise = appHostJsPromise || prepare.waitOnPrepare().then(function () {
-            return createHostJsFile(appHost, ['js', 'handlers', 'clobbers'])
+            return createHostJsFile(appHost, ['js', 'handlers', 'clobbers']);
         }).then(function (pluginList) {
             appHostJsPromise = null;
             return pluginList;

--- a/src/server/telemetry-helper.js
+++ b/src/server/telemetry-helper.js
@@ -1,6 +1,4 @@
 var config = require('./config');
-var dirs = require('./dirs');
-var fs = require('fs');
 var plugins = require('./plugins');
 
 function handleClientTelemetry(telemetryData) {
@@ -14,7 +12,7 @@ function handleClientTelemetry(telemetryData) {
         props = {};
         Object.keys(telemetryData.props).forEach(function (key) {
             if (key === 'handled') {
-                props[key] = telemetryData.props[key]
+                props[key] = telemetryData.props[key];
             } else {
                 piiProps[key] = telemetryData.props[key];
             }
@@ -33,4 +31,4 @@ function sendTelemetry(event, props, piiProps) {
 module.exports = {
     handleClientTelemetry: handleClientTelemetry,
     sendTelemetry: sendTelemetry
-}
+};

--- a/src/server/xhr-proxy.js
+++ b/src/server/xhr-proxy.js
@@ -9,7 +9,7 @@ module.exports.attach = function (app) {
 
         request.headers.host = requestURL.host;
         // fixes encoding issue
-        delete request.headers["accept-encoding"];
+        delete request.headers['accept-encoding'];
 
         var options = {
             host: requestURL.host,

--- a/src/simulate.js
+++ b/src/simulate.js
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-var Q = require('q'),
-    fs = require('fs'),
+var fs = require('fs'),
     cordovaServe = require('cordova-serve'),
     path = require('path'),
     config = require('./server/config'),
@@ -37,7 +36,7 @@ var launchServer = function (opts) {
     if (fs.existsSync(middlewarePath + '.js')) {
         require(middlewarePath).attach(server.app, dirs);
     }
-    
+
     /* attach CORS proxy middleware */
     if (!!opts.corsproxy) {
         require('./server/xhr-proxy').attach(server.app);


### PR DESCRIPTION
Hi! This PR is for adding the JS implementation of the native call to `CoreAndroid.backHistory` that is executed when `navigator.app.backHistory()` is called.
I also remove some unused variables in all of the modules and replace double quotes with single quotes. There's no well-defined convention about this, but since in the majority of the modules we are using single quotes, I replace them with single quotes.

Thanks!