### PR TITLE
Support for debug-host and viewport resizing

### DIFF
--- a/src/modules/messages.js
+++ b/src/modules/messages.js
@@ -75,7 +75,6 @@ Messages.prototype = {
     },
 
     // Emit and handle messages
-
     emit: function (message, data, isGlobal) {
         // Pass the message across the socket
         var eventName,
@@ -97,6 +96,15 @@ Messages.prototype = {
 
         // Notify any local listeners
         notify.call(this, messagesObj, message, data);
+    },
+    
+    // Emit messages destined to external debug-hosts
+    emitDebug: function(message, data) {
+        this.socket.emit('debug-message', {
+            pluginId: this.pluginId,
+            message: message,
+            data: data
+        });
     },
 
     on: function (message, handler, isGlobal) {

--- a/src/plugins/viewport/debug-host.json
+++ b/src/plugins/viewport/debug-host.json
@@ -1,0 +1,7 @@
+{
+    "alwaysActivateIfDebugHost": true,
+    "messages": [
+        "reset-viewport",
+        "resize-viewport"
+    ]
+}

--- a/src/plugins/viewport/sim-host-panels.html
+++ b/src/plugins/viewport/sim-host-panels.html
@@ -1,0 +1,12 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+
+<cordova-panel id="viewport" caption="Viewport (Screen Size)">
+    <cordova-group id="viewport-options">
+        <cordova-radio id="viewport-desktop" checked="true">Use full browser window</cordova-radio>
+        <cordova-radio id="viewport-device">Use predefined screen size:</cordova-radio>
+        <cordova-combo id="viewport-device-list"></cordova-combo>
+        <cordova-radio id="viewport-custom">Use these screen dimensions:</cordova-radio>
+        <cordova-text-entry label="Width:" id="viewport-custom-width"></cordova-text-entry>
+        <cordova-text-entry label="Height:" id="viewport-custom-height"></cordova-text-entry>
+    </cordova-group>
+</cordova-panel>

--- a/src/plugins/viewport/sim-host.js
+++ b/src/plugins/viewport/sim-host.js
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+var telemetry = require('telemetry-helper');
+
+var baseProps = {
+    plugin: 'viewport',
+    panel: 'viewport'
+};
+var devices = [
+    { 'id': 'AcerA500', 'name': 'Acer A500', 'width': 800, 'height': 1280 },
+    { 'id': 'Bold9700', 'name': 'BlackBerry Bold 9700', 'width': 480, 'height': 360 },
+    { 'id': 'Bold9900', 'name': 'BlackBerry Bold 9900', 'width': 640, 'height': 480 },
+    { 'id': 'Curve9300', 'name': 'BlackBerry Curve 9300', 'width': 320, 'height': 240 },
+    { 'id': 'Curve9350-9360-9370', 'name': 'BlackBerry Curve 9350/9360/9370', 'width': 480, 'height': 360 },
+    { 'id': 'FWVGA', 'name': 'Generic - FWVGA (480x854)', 'width': 480, 'height': 854 },
+    { 'id': 'G1', 'name': 'HTC G1', 'width': 320, 'height': 480 },
+    { 'id': 'HPPre3', 'name': 'HP Pre 3', 'width': 480, 'height': 800 },
+    { 'id': 'HPVeer', 'name': 'HP Veer', 'width': 320, 'height': 400 },
+    { 'id': 'HVGA', 'name': 'Generic - HVGA (320x480)', 'width': 320, 'height': 480 },
+    { 'id': 'iPad', 'name': 'iPad', 'width': 768, 'height': 1024 },
+    { 'id': 'iPad3', 'name': 'iPad 3', 'width': 1536, 'height': 2048 },
+    { 'id': 'iPhone3', 'name': 'iPhone 3G/3Gs', 'width': 320, 'height': 480 },
+    { 'id': 'iPhone4', 'name': 'iPhone 4/4s', 'width': 640, 'height': 960 },
+    { 'id': 'iPhone5', 'name': 'iPhone 5', 'width': 640, 'height': 1136 },
+    { 'id': 'Legend', 'name': 'HTC Legend', 'width': 320, 'height': 480 },
+    { 'id': 'Nexus', 'name': 'Nexus One', 'width': 480, 'height': 800 },
+    { 'id': 'Nexus4', 'name': 'Nexus 4', 'width': 768, 'height': 1280 },
+    { 'id': 'Nexus7', 'name': 'Nexus 7 (Tablet)', 'width': 800, 'height': 1280 },
+    { 'id': 'NexusGalaxy', 'name': 'Nexus (Galaxy)', 'width': 720, 'height': 1280 },
+    { 'id': 'NexusS', 'name': 'Nexus S', 'width': 480, 'height': 800 },
+    { 'id': 'NokiaN8', 'name': 'Nokia N8', 'width': 360, 'height': 640 },
+    { 'id': 'NokiaN97', 'name': 'Nokia N97/5800 (touch)', 'width': 360, 'height': 640 },
+    { 'id': 'PalmPre', 'name': 'Palm Pre', 'width': 320, 'height': 480 },
+    { 'id': 'PalmPre2', 'name': 'Palm Pre 2', 'width': 320, 'height': 480 },
+    { 'id': 'Pearl9100', 'name': 'BlackBerry Pearl 9100', 'width': 360, 'height': 400 },
+    { 'id': 'Playbook', 'name': 'BlackBerry Playbook', 'width': 1024, 'height': 600 },
+    { 'id': 'Q10', 'name': 'BlackBerry Q10', 'width': 720, 'height': 720 },
+    { 'id': 'QVGA', 'name': 'Generic - QVGA (240X320)', 'width': 240, 'height': 320 },
+    { 'id': 'Style9670', 'name': 'BlackBerry Style 9670', 'width': 360, 'height': 400 },
+    { 'id': 'Tattoo', 'name': 'HTC Tattoo', 'width': 240, 'height': 320 },
+    { 'id': 'Torch9800', 'name': 'BlackBerry Torch 9800', 'width': 360, 'height': 480 },
+    { 'id': 'Torch9810', 'name': 'BlackBerry Torch 9810', 'width': 480, 'height': 640 },
+    { 'id': 'Torch9860-9850', 'name': 'BlackBerry Torch 9860/9850', 'width': 480, 'height': 800 },
+    { 'id': 'Wave', 'name': 'Samsung Wave', 'width': 480, 'height': 800 },
+    { 'id': 'WQVGA', 'name': 'Generic - WQVGA (240x480)', 'width': 240, 'height': 400 },
+    { 'id': 'WVGA', 'name': 'Generic - WVGA (480x800)', 'width': 480, 'height': 800 },
+    { 'id': 'Z10', 'name': 'BlackBerry Z10', 'width': 768, 'height': 1280 }
+];
+var previousViewportSelection;
+
+module.exports = function (messages) {
+    function initialize() {
+        // Populate predefined device list
+        var deviceList = document.getElementById('viewport-device-list');
+
+        devices.forEach(function (device) {
+            var option = document.createElement('option');
+            option.value = device.id;
+
+            var caption = document.createTextNode(device.name);
+            option.appendChild(caption);
+
+            option.setAttribute('_width', device.width);
+            option.setAttribute('_height', device.height);
+
+            deviceList.appendChild(option);
+        });
+
+        // Handle radio button change        
+        document.getElementById('viewport-desktop').onclick = handleRadioClick.bind(null, 'viewport-desktop');
+        document.getElementById('viewport-device').onclick = handleRadioClick.bind(null, 'viewport-device');
+        document.getElementById('viewport-custom').onclick = handleRadioClick.bind(null, 'viewport-custom');
+
+        // Handle device list selection change
+        deviceList.addEventListener('change', handleSelectDevice);
+
+        // Handle custom dimensions change
+        var customWidthTextEntry = document.getElementById('viewport-custom-width');
+        var customHeightTextEntry = document.getElementById('viewport-custom-height');
+
+        customWidthTextEntry.addEventListener('change', handleChangeCustomDimension.bind(null, 'width'));
+        customHeightTextEntry.addEventListener('change', handleChangeCustomDimension.bind(null, 'height'));
+
+        // Set default values
+        previousViewportSelection = 'viewport-desktop';
+        deviceList.value = 'WQVGA';
+        customWidthTextEntry.value = 480;
+        customHeightTextEntry.value = 800;
+
+        // Register telemetry
+        registerTelemetryEvents();
+    }
+
+    function handleRadioClick(radioName) {
+        if (radioName !== previousViewportSelection) {
+            previousViewportSelection = radioName;
+            telemetry.sendUITelemetry(Object.assign({}, baseProps, { control: radioName }));
+
+            switch (radioName) {
+                case 'viewport-desktop':
+                    messages.emitDebug('reset-viewport');
+                    break;
+                case 'viewport-device':
+                    handleSelectDevice();
+                    break;
+                case 'viewport-custom':
+                    notifyResize({
+                        width: document.getElementById('viewport-custom-width').value,
+                        height: document.getElementById('viewport-custom-height').value
+                    });
+            }
+        }
+    }
+
+    function handleSelectDevice() {
+        if (!document.getElementById('viewport-device').checked) {
+            return;
+        }
+
+        var deviceList = document.getElementById('viewport-device-list');
+        var option = deviceList.options[deviceList.selectedIndex];
+
+        notifyResize({
+            width: option.getAttribute('_width'),
+            height: option.getAttribute('_height')
+        });
+    }
+
+    function handleChangeCustomDimension(dimensionName, e) {
+        // Make sure the new value is an integer
+        var newValue = parseInt(e.target.value);
+
+        if (isNaN(newValue)) {
+            return;
+        }
+
+        // Resize the viewport if custom dimensions are selected
+        if (document.getElementById('viewport-custom').checked) {
+            var dimensions = {};
+
+            dimensions[dimensionName] = newValue;
+            notifyResize(dimensions);
+        }
+    }
+
+    function notifyResize(dimensions) {
+        var width = parseInt(dimensions.width || document.getElementById('viewport-custom-width').value);
+        var height = parseInt(dimensions.height || document.getElementById('viewport-custom-height').value);
+
+        if (isNaN(width) || isNaN(height)) {
+            return;
+        }
+
+        messages.emitDebug('resize-viewport', {
+            width: width,
+            height: height
+        });
+    }
+
+    function registerTelemetryForControl(controlId) {
+        document.getElementById(controlId).addEventListener('change', telemetry.sendUITelemetry.bind(this, Object.assign({}, baseProps, {
+            control: controlId
+        })));
+    }
+
+    function registerTelemetryEvents() {
+        // Register the simple events (onchange -> send the control ID).
+        var basicTelemetryEventControls = [
+            'viewport-custom-width',
+            'viewport-custom-height'
+        ];
+
+        basicTelemetryEventControls.forEach(function (controlId) {
+            registerTelemetryForControl(controlId);
+        });
+
+        // Register the event for the device combo box.
+        var deviceList = document.getElementById('viewport-device-list');
+
+        deviceList.addEventListener('change', function () {
+            var option = deviceList.options[deviceList.selectedIndex];
+
+            telemetry.sendUITelemetry(Object.assign({}, baseProps, {
+                control: 'viewport-device-list',
+                value: option.value
+            }));
+        });
+    }
+
+    return {
+        initialize: initialize
+    };
+};

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -8,16 +8,17 @@ var simulationFilePath;
 
 // module properties
 [
-    { name: 'liveReload'},
+    { name: 'debugHostHandlers', optional: true },
+    { name: 'forcePrepare' },
+    { name: 'liveReload' },
     { name: 'platform' },
     { name: 'platformRoot' },
-    { name: 'forcePrepare' },
     { name: 'projectRoot', single: true },
     { name: 'server', optional: true },
-    { name: 'telemetry', optional: true },
-    { name: 'xhrProxy', optional: true },
     { name: 'simHostOptions' },
-    { name: 'touchEvents', optional: true }
+    { name: 'telemetry', optional: true },
+    { name: 'touchEvents', optional: true },
+    { name: 'xhrProxy', optional: true }
 ].forEach(function (prop) {
     Object.defineProperty(module.exports, prop.name, {
         get: function () {

--- a/src/server/plugin-files.json
+++ b/src/server/plugin-files.json
@@ -9,5 +9,8 @@
     "js": "app-host.js",
     "handlers": "app-host-handlers.js",
     "clobbers": "app-host-clobbers.js"
+  },
+  "debug-host": {
+    "debug-host": "debug-host.json"
   }
 }

--- a/src/server/plugins.js
+++ b/src/server/plugins.js
@@ -26,29 +26,37 @@ function resetPluginsData() {
 }
 
 function initPlugins() {
-    // Always defined plugins
-    var pluginList = ['exec', 'events'];
-
-    var pluginPath = path.resolve(config.platformRoot, 'plugins');
-    if (fs.existsSync(pluginPath)) {
-        fs.readdirSync(pluginPath).forEach(function (file) {
-            if (fs.statSync(path.join(pluginPath, file)).isDirectory()) {
-                pluginList.push(file);
-            }
-        });
-    }
-
-    if (pluginList.indexOf('cordova-plugin-geolocation') === -1) {
-        pluginList.push('cordova-plugin-geolocation');
-    }
-
-    var projectRoot = config.projectRoot;
-    
     resetPluginsData();
-    pluginList.forEach(function (pluginId) {
+
+    // Find the default plugins
+    var projectRoot = config.projectRoot;
+    var defaultPlugins = ['exec', 'events'];
+    var simulatedDefaultPlugins = {};
+
+    defaultPlugins.forEach(function (pluginId) {
+        var pluginPath = findPluginPath(projectRoot, pluginId);
+
+        if (pluginPath) {
+            simulatedDefaultPlugins[pluginId] = pluginPath;
+            pluginsTelemetry.simulatedBuiltIn.push(pluginId);
+        }
+    });
+
+    // Find the project plugins that can be simulated.
+    var projectPluginsRoot = path.resolve(config.platformRoot, 'plugins');
+    var rawProjectPluginList = getDirectoriesInPath(projectPluginsRoot);
+
+    if (rawProjectPluginList.indexOf('cordova-plugin-geolocation') < 0) {
+        rawProjectPluginList.unshift('cordova-plugin-geolocation');
+    }
+
+    var simulatedProjectPlugins = {};
+
+    rawProjectPluginList.forEach(function (pluginId) {
         var pluginFilePath = findPluginPath(projectRoot, pluginId);
-        if (pluginFilePath) {
-            plugins[pluginId] = pluginFilePath;
+
+        if (pluginFilePath && shouldUsePluginWithDebugHost(pluginFilePath, true)) {
+            simulatedProjectPlugins[pluginId] = pluginFilePath;
 
             if (pluginFilePath.indexOf(dirs.plugins) === 0) {
                 pluginsTelemetry.simulatedBuiltIn.push(pluginId);
@@ -59,6 +67,39 @@ function initPlugins() {
             pluginsTelemetry.notSimulated.push(pluginId);
         }
     });
+
+    // Find built-in debug-host plugins (plugins that should be part of the simulation due to the presence of a
+    // debug-host, even if they weren't added to the project).
+    var simulatedDebugHostPlugins = {};
+
+    if (config.debugHostHandlers) {
+        var rawBuiltInPluginList = getDirectoriesInPath(dirs.plugins);
+
+        rawBuiltInPluginList.forEach(function (pluginId) {
+            if (simulatedDefaultPlugins[pluginId] || simulatedProjectPlugins[pluginId]) {
+                return;
+            }
+
+            var pluginPath = path.join(dirs.plugins, pluginId);
+
+            if (pluginPath && shouldUsePluginWithDebugHost(pluginPath)) {
+                simulatedDebugHostPlugins[pluginId] = pluginPath;
+                pluginsTelemetry.simulatedBuiltIn.push(pluginId);
+            }
+        });
+    }
+
+    // Register the plugins. The default plugins are first, then the debug-host plugins (to have the correct order in
+    // sim-host).
+    function registerPlugins(pluginDictionary) {
+        Object.keys(pluginDictionary).forEach(function (pluginId) {
+            plugins[pluginId] = pluginDictionary[pluginId];
+        });
+    }
+
+    registerPlugins(simulatedDefaultPlugins);
+    registerPlugins(simulatedDebugHostPlugins);
+    registerPlugins(simulatedProjectPlugins);
 
     telemetry.sendTelemetry('plugin-list', { simulatedBuiltIn: pluginsTelemetry.simulatedBuiltIn },
         { simulatedNonBuiltIn: pluginsTelemetry.simulatedNonBuiltIn, notSimulated: pluginsTelemetry.notSimulated });
@@ -118,6 +159,61 @@ function findBuiltInPluginSourceFilePath(pluginId, file) {
     // In case plugin id is in old style, try mapping to new style to see if we have support for that.
     pluginId = pluginMapper[pluginId];
     return pluginId ? findBuiltInPluginSourceFilePath(pluginId, file) : null;
+}
+
+function shouldUsePluginWithDebugHost(pluginPath, pluginAddedToProject) {
+    pluginAddedToProject = !!pluginAddedToProject;
+
+    // Check whether the plugin defines some debug-host requirements.
+    var debugHostFilePath = path.join(pluginPath, pluginSimulationFiles['debug-host']['debug-host'])
+
+    if (!fs.existsSync(debugHostFilePath)) {
+        // Plugin doesn't have any requirements for debug-host. Always use the plugin if it was added to the project.
+        return pluginAddedToProject;
+    }
+
+    var debugHostOptions;
+
+    try {
+        debugHostOptions = JSON.parse(fs.readFileSync(debugHostFilePath, 'utf8'));
+    } catch (err) {
+        // Can't determine plugin's debug-host requirements, so ignore them. Use the plugin if it was added to the
+        // project.
+        return pluginAddedToProject;
+    }
+
+    // If the plugin requires debug-host handlers, check if there is a debug-host and whether it supports them.
+    if (debugHostOptions.messages && Array.isArray(debugHostOptions.messages)) {
+        if (!config.debugHostHandlers) {
+            return false;
+        }
+
+        for (var i = 0; i < debugHostOptions.messages.length; ++i) {
+            var messageName = debugHostOptions.messages[i];
+
+            if (config.debugHostHandlers.indexOf(messageName) < 0) {
+                // The plugin requires a handler not supported by the current debug-host, so it can't be used.
+                return false;
+            }
+        }
+    }
+
+    // The current debug-host supports all required handlers for the plugin.
+    return pluginAddedToProject || !!debugHostOptions.alwaysActivateIfDebugHost;
+}
+
+function getDirectoriesInPath(dirPath) {
+    var dirList = [];
+
+    if (fs.existsSync(dirPath)) {
+        fs.readdirSync(dirPath).forEach(function (file) {
+            if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
+                dirList.push(file);
+            }
+        });
+    }
+
+    return dirList;
 }
 
 function getRouter() {

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -167,6 +167,11 @@ function initialize() {
             get: function () {
                 return this.shadowRoot.querySelector('input').value;
             }
+        },
+        disabled: {
+            set: function (value) {
+                setValueSafely(this.shadowRoot.querySelector('input'), 'disabled', value);
+            }
         }
     }, function () {
         this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');

--- a/src/simulate.js
+++ b/src/simulate.js
@@ -59,7 +59,7 @@ var launchServer = function (opts) {
         appUrl = urlRoot + parseStartPage(projectRoot);
         simHostUrl = urlRoot + 'simulator/index.html';
         log.log('Server started:\n- App running at: ' + appUrl + '\n- Sim host running at: ' + simHostUrl);
-        return { appUrl: appUrl, simHostUrl: simHostUrl };
+        return { urlRoot: urlRoot, appUrl: appUrl, simHostUrl: simHostUrl };
     });
 };
 


### PR DESCRIPTION
- Added support for an external debug-host to register with the server, specifying which debug messages it can handle
- Added support for plugins to activate based on the presence of a debug-host and specific debug-host message handlers
- Added the viewport plugin, which allows users to request viewport resizing of their running app (requires an external debug-host to do the actual resizing; this plugin merely sends messages to the connected debug-host)

Please note that for now, the viewport plugin won't sync up with the device plugin (changing a predefined device in one will not update the other). This can be tracked as an Enhancement issue and be done at a later time.