### PR TITLE
Fix app-host exec handler arguments to match the spec.

### DIFF
--- a/src/app-host/app-host.js
+++ b/src/app-host/app-host.js
@@ -101,7 +101,7 @@ function exec(success, fail, service, action, args) {
 
         // Ensure local handlers are executed asynchronously.
         setTimeout(function () {
-            handler(success, fail, service, action, args);
+            handler(success, fail, args);
         }, 0);
     } else {
         var execIndex = nextExecCacheIndex++;


### PR DESCRIPTION
Hi! This PR is a minor fix to the execution of the exec handler in app-host side. The `app-host-handlers.js` specification is the same as sim-host-handlers.js specification, meaning that the exec call arguments are success callback,  fail callback and an array of arguments. In the app-host exec implementation, the handler was executed without following the spec, causing some bad behaviour in the plugin usages. You can try it with the mobilespec app, by runnig the manual test of the camera plugin, that has `app-host-handlers.js`. 
With this fix, we follow the spec, and app-host exec call behaves exactly as the [sim-host side implementation](https://github.com/Microsoft/cordova-simulate/blob/master/src/sim-host/protocol/socket.js#L47).

Thanks!