### PR TITLE
Fix copy-paste typo in 3rd party attribution.

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -81,7 +81,7 @@ momentjs.com
 accounting.js v0.4.2
 Copyright 2014 Open Exchange Rates, MIT license
 http://openexchangerates.github.io/accounting.js
-(see src/plugins/cordova-plugin-globalization/moment.js)
+(see src/plugins/cordova-plugin-globalization/accounting.js)
 
 -- jQuery JavaScript Library --------------------------------------------------
 


### PR DESCRIPTION
Correct the source reference in third party notices for `accounting.js`.