### PR TITLE
cordova-plugin-inappbrowser simulation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This preview version currently includes built-in support for the following Cordo
 * [cordova-plugin-file](https://github.com/apache/cordova-plugin-file)
 * [cordova-plugin-geolocation](https://github.com/apache/cordova-plugin-geolocation)
 * [cordova-plugin-globalization](https://github.com/apache/cordova-plugin-globalization)
+* [cordova-plugin-inappbrowser](https://github.com/apache/cordova-plugin-inappbrowser)
 * [cordova-plugin-media](https://github.com/apache/cordova-plugin-media)
 * [cordova-plugin-network-information](https://github.com/apache/cordova-plugin-network-information)
 * [cordova-plugin-vibration](https://github.com/apache/cordova-plugin-vibration)

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -252,6 +252,34 @@ self = module.exports = {
 
     typeName: function (val) {
         return Object.prototype.toString.call(val).slice(8, -1);
+    },
+
+    parseUrl: function (url) {
+        var a = document.createElement('a');
+
+        a.href = url;
+
+        return {
+            href: a.href,
+            host: a.host,
+            origin: a.origin,
+            port: a.port,
+            protocol: a.protocol,
+            search: a.search
+        };
+    },
+
+    isSameOriginRequest: function (url) {
+        url = this.parseUrl(url);
+
+        if (url.port !== location.port) {
+            return false;
+        }
+
+        var sameOrigin = url.href.match(location.origin.replace(/www\./, '')) ||
+            !url.href.match(/^https?:\/\/|^file:\/\//);
+
+        return !!sameOrigin;
     }
 };
 

--- a/src/modules/xhr-proxy.js
+++ b/src/modules/xhr-proxy.js
@@ -1,33 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Based in part on code from Apache Ripple, https://github.com/apache/incubator-ripple
 
-var isSameOriginRequest = function (url) {
-    url = parseUrl(url);
-
-    if (url.port !== location.port) {
-        return false;
-    }
-
-    var sameOrigin = url.href.match(location.origin.replace(/www\./, '')) ||
-        !url.href.match(/^https?:\/\/|^file:\/\//);
-
-    return !!sameOrigin;
-};
-
-var parseUrl = function (url) {
-    var a = document.createElement('a');
-
-    a.href = url;
-
-    return {
-        href: a.href,
-        host: a.host,
-        origin: a.origin,
-        port: a.port,
-        protocol: a.protocol,
-        search: a.search
-    };
-};
+var utils = require('utils');
 
 var init = function () {
     var _XMLHttpRequest = XMLHttpRequest;
@@ -39,7 +13,7 @@ var init = function () {
             };
 
         xhr.open = function (method, url) {
-            var sameOrigin = isSameOriginRequest(url);
+            var sameOrigin = utils.isSameOriginRequest(url);
 
             if (!sameOrigin) {
                 url = '/xhr_proxy?rurl=' + escape(url);

--- a/src/plugins/cordova-plugin-inappbrowser/app-host-handlers.js
+++ b/src/plugins/cordova-plugin-inappbrowser/app-host-handlers.js
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+module.exports = function () {
+    var IframeBrowser = require('./inapp-browser').IframeBrowser,
+        SystemBrowser = require('./inapp-browser').SystemBrowser,
+        instance;
+
+    return {
+        'InAppBrowser': {
+            'open': function (success, fail, args) {
+                // args[0]: url, args[1]: target, args[2]: options
+                var Constructor;
+
+                switch (args[1]) {
+                case '_system':
+                    // open in a new browser tab
+                    Constructor = SystemBrowser;
+                    break;
+                case '_blank':
+                    Constructor = IframeBrowser;
+                    break;
+                default:
+                    // "_self" and any other option, use the same tab
+                    window.location = args[0];
+                    return;
+                }
+
+                instance = new Constructor(args[0], args[2], success, fail);
+            },
+            'show': function () {
+                if (instance) {
+                    instance.show();
+                }
+            },
+            'close': function () {
+                if (instance) {
+                    instance.close();
+                }
+            },
+            'injectScriptCode': function (success, fail, args) {
+                instance.injectScriptCode(success, args);
+            },
+            'injectScriptFile': function (success, fail, args) {
+                instance.injectScriptFile(success, args);
+            },
+            'injectStyleCode': function (success, fail, args) {
+                instance.injectStyleCode(success, args);
+            },
+            'injectStyleFile': function (success, fail, args) {
+                instance.injectStyleFile(success, args);
+            }
+        }
+    };
+};

--- a/src/plugins/cordova-plugin-inappbrowser/app-host-handlers.js
+++ b/src/plugins/cordova-plugin-inappbrowser/app-host-handlers.js
@@ -1,8 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-module.exports = function () {
+module.exports = function (messages) {
     var Browser = require('./inapp-browser'),
         instance;
+
+    messages.call('inAppBrowserSelected')
+        .then(function (value) {
+            Browser.setDefaultInAppBrowser(value);
+        });
+
+    messages.on('inappbrowser-selected', function (event, value) {
+        Browser.setDefaultInAppBrowser(value);
+    });
 
     function execute(fnName) {
         if (!instance) {

--- a/src/plugins/cordova-plugin-inappbrowser/app-host-handlers.js
+++ b/src/plugins/cordova-plugin-inappbrowser/app-host-handlers.js
@@ -31,6 +31,7 @@ module.exports = function () {
             },
             'close': function () {
                 execute('close');
+                instance = null;
             },
             'injectScriptCode': function (success, fail, args) {
                 execute('injectScriptCode', success, args);

--- a/src/plugins/cordova-plugin-inappbrowser/app-host-handlers.js
+++ b/src/plugins/cordova-plugin-inappbrowser/app-host-handlers.js
@@ -1,53 +1,48 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 module.exports = function () {
-    var IframeBrowser = require('./inapp-browser').IframeBrowser,
-        SystemBrowser = require('./inapp-browser').SystemBrowser,
+    var Browser = require('./inapp-browser'),
         instance;
+
+    function execute(fnName) {
+        if (!instance) {
+            return;
+        }
+
+        var fn = instance[fnName],
+            args;
+
+        if (Object.keys(arguments).length > 1) {
+            // remove the first element since it is the "fnName" parameter
+            Array.prototype.shift.apply(arguments);
+            args = arguments;
+        }
+
+        return fn.apply(instance, args);
+    }
 
     return {
         'InAppBrowser': {
             'open': function (success, fail, args) {
-                // args[0]: url, args[1]: target, args[2]: options
-                var Constructor;
-
-                switch (args[1]) {
-                case '_system':
-                    // open in a new browser tab
-                    Constructor = SystemBrowser;
-                    break;
-                case '_blank':
-                    Constructor = IframeBrowser;
-                    break;
-                default:
-                    // "_self" and any other option, use the same tab
-                    window.location = args[0];
-                    return;
-                }
-
-                instance = new Constructor(args[0], args[2], success, fail);
+                instance = Browser.create(success, fail, args);
             },
             'show': function () {
-                if (instance) {
-                    instance.show();
-                }
+                execute('show');
             },
             'close': function () {
-                if (instance) {
-                    instance.close();
-                }
+                execute('close');
             },
             'injectScriptCode': function (success, fail, args) {
-                instance.injectScriptCode(success, args);
+                execute('injectScriptCode', success, args);
             },
             'injectScriptFile': function (success, fail, args) {
-                instance.injectScriptFile(success, args);
+                execute('injectScriptFile', success, args);
             },
             'injectStyleCode': function (success, fail, args) {
-                instance.injectStyleCode(success, args);
+                execute('injectStyleCode', success, args);
             },
             'injectStyleFile': function (success, fail, args) {
-                instance.injectStyleFile(success, args);
+                execute('injectStyleFile', success, args);
             }
         }
     };

--- a/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
+++ b/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
@@ -3,6 +3,8 @@
 // Events taken from cordova-plugin-inappbrowser implementation, and iframe approach
 // based from https://github.com/apache/cordova-plugin-inappbrowser/blob/master/src/browser/InAppBrowserProxy.js
 
+var _defaultInAppBrowserType = 'iframe';
+
 /**
  * @param {string} url
  * @param {Array} options
@@ -395,11 +397,21 @@ function create(success, fail, args) {
         window.location = args[0];
         return;
     default:
-        // "_blank" and any other option, use the iframe browser
-        Constructor = IframeBrowser;
+        if (_defaultInAppBrowserType === 'iframe') {
+            // "_blank" and any other option, use the iframe browser
+            Constructor = IframeBrowser;
+        } else {
+            // new browser window
+            Constructor = SystemBrowser;
+        }
     }
 
     return new Constructor(args[0], args[2], success, fail);
 }
 
+function setDefaultInAppBrowser(value) {
+    _defaultInAppBrowserType = value;
+}
+
 module.exports.create = create;
+module.exports.setDefaultInAppBrowser = setDefaultInAppBrowser;

--- a/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
+++ b/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
@@ -1,0 +1,260 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+/**
+ * @param {string} url
+ * @param {Array} options
+ * @param {function} success
+ * @param {function} fail
+ * @constructor
+ */
+function InAppBrowser(url, options, success, fail) {
+    this._url = url;
+    this._options = {};
+    this._callbacks = {
+        success: success,
+        fail: fail
+    };
+
+    options = (options.trim() === '') ? [] : options.split(';');
+
+    // prepare options object
+    options.forEach(function (option) {
+        var prop = option.split('='); // "theOption=value"
+        this._options[prop[0]] = prop[1];
+    }.bind(this));
+
+    if (this._options.hidden !== 'yes') {
+        this.show();
+    }
+}
+
+/**
+ * @enum
+ */
+InAppBrowser.Events = {
+    LOAD_START: 'loadstart',
+    LOAD_STOP: 'loadstop',
+    LOAD_ERROR: 'loaderror',
+    EXIT: 'exit'
+};
+
+InAppBrowser.prototype.show = function () {};
+
+InAppBrowser.prototype.close = function () {};
+
+InAppBrowser.prototype.injectScriptCode = function (callback, args) {
+    console.error('InAppBrowser "injectScriptCode" simulation not supported');
+};
+
+InAppBrowser.prototype.injectScriptFile = function (callback, args) {
+    console.error('InAppBrowser "injectScriptFile" simulation not supported');
+};
+
+InAppBrowser.prototype.injectStyleCode = function (callback, args) {
+    console.error('InAppBrowser "injectStyleCode" simulation not supported');
+};
+
+InAppBrowser.prototype.injectStyleFile = function (callback, args) {
+    console.error('InAppBrowser "injectScriptFile" simulation not supported');
+};
+
+/**
+ * @param {string} eventName
+ * @private
+ */
+InAppBrowser.prototype._success = function (eventName) {
+    this._callbacks.success({
+        type: eventName
+    });
+};
+
+/**
+ * @param {string} url
+ * @param {Array} options
+ * @param {function} success
+ * @param {function} fail
+ * @constructor
+ */
+function SystemBrowser(url, options, success, fail) {
+    InAppBrowser.call(this, url, options, success, fail);
+
+    this._window = null;
+}
+
+SystemBrowser.prototype = Object.create(InAppBrowser.prototype);
+SystemBrowser.prototype.constructor = SystemBrowser;
+SystemBrowser.prototype.parentClass = InAppBrowser.prototype;
+
+SystemBrowser.prototype.show = function () {
+    if (!this._window) {
+        var modulemapper = cordova.require('cordova/modulemapper'),
+            windowOpen = modulemapper.getOriginalSymbol(window, 'window.open');
+
+        this._success(InAppBrowser.Events.LOAD_START);
+
+        this._window = windowOpen.call(window, this._url, '_blank');
+    }
+};
+
+SystemBrowser.prototype.close = function () {
+    if (this._window) {
+        this._window.close();
+        this._window = null;
+
+        this._success(InAppBrowser.Events.EXIT);
+    }
+};
+
+/**
+ * @param {string} url
+ * @param {Array} options
+ * @param {function} success
+ * @param {function} fail
+ * @constructor
+ */
+function IframeBrowser(url, options, success, fail) {
+    this._container = null;
+    this._frame = null;
+
+    InAppBrowser.call(this, url, options, success, fail);
+}
+
+IframeBrowser.prototype = Object.create(InAppBrowser.prototype);
+IframeBrowser.prototype.constructor = IframeBrowser;
+IframeBrowser.prototype.parentClass = InAppBrowser.prototype;
+
+IframeBrowser.prototype.show = function () {
+    this._createFrame();
+
+    this._frame.src = this._url;
+    this._container.style.display = 'block';
+};
+
+IframeBrowser.prototype.close = function () {
+    if (this._container) {
+        this._container.parentNode.removeChild(this._container);
+        this._container = null;
+        this._frame = null;
+
+        this._success(InAppBrowser.Events.EXIT);
+    }
+};
+
+IframeBrowser.prototype.hide = function () {
+    if (this._container) {
+        this._container.style.display = 'none';
+    }
+};
+
+IframeBrowser.prototype.injectScriptCode = function (callback, args) {
+    if (this._container && this._frame) {
+        var code = args[0],
+            hasCallback = args[1];
+
+        try {
+            var result = this._frame.contentWindow.eval(code);
+            if (hasCallback) {
+                result = result || [];
+                callback(result);
+            }
+        } catch (error) {
+            console.error('Error occured while trying to inject script', error);
+        }
+    }
+};
+
+IframeBrowser.prototype.injectScriptFile = function (callback, args) {
+    var file = args[0];
+    var code = '(function () {' +
+        'var head = document.getElementsByTagName("head")[0];' +
+        'var script = document.createElement("script");' +
+        'script.type = "text/javascript";' +
+        'script.id = "inappbrowser-inject-script";' +
+        'script.src = "' + file + '";' +
+        'head.appendChild(script);' +
+        '}());';
+
+    args[0] = code;
+
+    this.injectScriptCode(callback, args);
+};
+
+IframeBrowser.prototype.injectStyleCode = function (callback, args) {
+    // TODO
+};
+
+IframeBrowser.prototype.injectStyleFile = function (callback, args) {
+    // TODO
+};
+
+/**
+ * @private
+ */
+IframeBrowser.prototype._createFrame = function () {
+    if (!this._container) {
+        this._container = document.createElement('div');
+        this._frame = document.createElement('iframe');
+
+        // container style
+        var style = this._container.style;
+        style.position = 'absolute';
+        style.border = '0';
+        style.backgroundColor = '#ffffff';
+        style.width = '100%';
+        style.height = '100%';
+        style.zIndex = '10000';
+
+        // iframe style
+        style = this._frame.style;
+        style.border = '0';
+        style.width = '100%';
+
+        if (!this._options.location || this._options.location === 'yes') {
+            style.height = 'calc(100% - 35px)';
+
+            this._container.appendChild(this._createNavigationBar());
+        } else {
+             style.height = '100%';
+        }
+
+        this._container.appendChild(this._frame);
+
+        document.body.appendChild(this._container);
+
+        this._frame.addEventListener('pageshow', this._success.bind(this, InAppBrowser.Events.LOAD_START));
+        this._frame.addEventListener('load', this._success.bind(this, InAppBrowser.Events.LOAD_STOP));
+        this._frame.addEventListener('error', this._success.bind(this, InAppBrowser.Events.LOAD_ERROR));
+        this._frame.addEventListener('abort', this._success.bind(this, InAppBrowser.Events.LOAD_ERROR ));
+    }
+};
+
+/**
+ * @private
+ */
+IframeBrowser.prototype._createNavigationBar = function () {
+    var navigationDiv = document.createElement('div'),
+        wrapper = document.createElement('div'),
+        closeButton = document.createElement('button');
+
+    navigationDiv.style.height = '30px';
+    navigationDiv.style.padding = '2px';
+    navigationDiv.style.backgroundColor = '#404040';
+
+    closeButton.innerHTML = '✖';
+    closeButton.style.width = '30px';
+    closeButton.style.height = '25px';
+
+    closeButton.addEventListener('click', function (e) {
+        setTimeout(function () {
+            this.close();
+        }.bind(this), 0);
+    }.bind(this));
+
+    wrapper.appendChild(closeButton);
+    navigationDiv.appendChild(wrapper);
+
+    return navigationDiv;
+};
+
+module.exports.IframeBrowser = IframeBrowser;
+module.exports.SystemBrowser = SystemBrowser;

--- a/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
+++ b/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
@@ -285,11 +285,13 @@ IframeBrowser.prototype._createFrame = function () {
     // container style
     var style = this._container.style;
     style.position = 'absolute';
+    style.top = style.left = '0';
     style.border = '0';
     style.backgroundColor = '#ffffff';
     style.zIndex = '10000';
     style.width = document.body.clientWidth + 'px';
     style.height = document.body.clientHeight + 'px';
+    style.minHeight = style.minWidth = '100%';
 
     // iframe style
     style = this._iframe.style;

--- a/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
+++ b/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
@@ -131,7 +131,7 @@ SystemBrowser.prototype.close = function () {
  */
 function IframeBrowser(url, options, success, fail) {
     this._container = null;
-    this._frame = null;
+    this._iframe = null;
     this._resizeCallback = this._resizeContainer.bind(this);
     this._isVisible = false;
 
@@ -149,7 +149,7 @@ IframeBrowser.prototype.show = function () {
 
     this._isVisible = true;
 
-    this._frame.src = this._url;
+    this._iframe.src = this._url;
     this._container.style.display = 'block';
 
     this._resizeContainer();
@@ -159,7 +159,7 @@ IframeBrowser.prototype.close = function () {
     if (this._container) {
         this._container.parentNode.removeChild(this._container);
         this._container = null;
-        this._frame = null;
+        this._iframe = null;
         this._isVisible = false;
 
         this._success(InAppBrowser.Events.EXIT);
@@ -176,7 +176,7 @@ IframeBrowser.prototype.hide = function () {
 };
 
 IframeBrowser.prototype.injectScriptCode = function (callback, args) {
-    if (this._container && this._frame) {
+    if (this._container && this._iframe) {
         var code = args[0].replace(/\r?\n|\r/g, ''),
             hasCallback = args[1];
 
@@ -208,7 +208,7 @@ IframeBrowser.prototype.injectScriptFile = function (callback, args) {
 };
 
 IframeBrowser.prototype.injectStyleCode = function (callback, args) {
-    if (this._container && this._frame) {
+    if (this._container && this._iframe) {
         var css = args[0].replace(/\r?\n|\r/g, ''),
             hasCallback = args[1];
 
@@ -235,7 +235,7 @@ IframeBrowser.prototype.injectStyleCode = function (callback, args) {
 };
 
 IframeBrowser.prototype.injectStyleFile = function (callback, args) {
-    if (this._container && this._frame) {
+    if (this._container && this._iframe) {
         var file = args[0],
             hasCallback = args[1];
 
@@ -264,7 +264,7 @@ IframeBrowser.prototype.injectStyleFile = function (callback, args) {
  */
 IframeBrowser.prototype._createFrame = function () {
     this._container = document.createElement('div');
-    this._frame = document.createElement('iframe');
+    this._iframe = document.createElement('iframe');
 
     // container style
     var style = this._container.style;
@@ -276,7 +276,7 @@ IframeBrowser.prototype._createFrame = function () {
     style.height = document.body.clientHeight + 'px';
 
     // iframe style
-    style = this._frame.style;
+    style = this._iframe.style;
     style.border = '0';
     style.width = '100%';
 
@@ -288,14 +288,14 @@ IframeBrowser.prototype._createFrame = function () {
         style.height = '100%';
     }
 
-    this._container.appendChild(this._frame);
+    this._container.appendChild(this._iframe);
 
     document.body.appendChild(this._container);
 
-    this._frame.addEventListener('pageshow', this._success.bind(this, InAppBrowser.Events.LOAD_START));
-    this._frame.addEventListener('load', this._success.bind(this, InAppBrowser.Events.LOAD_STOP));
-    this._frame.addEventListener('error', this._success.bind(this, InAppBrowser.Events.LOAD_ERROR));
-    this._frame.addEventListener('abort', this._success.bind(this, InAppBrowser.Events.LOAD_ERROR));
+    this._iframe.addEventListener('pageshow', this._success.bind(this, InAppBrowser.Events.LOAD_START));
+    this._iframe.addEventListener('load', this._success.bind(this, InAppBrowser.Events.LOAD_STOP));
+    this._iframe.addEventListener('error', this._success.bind(this, InAppBrowser.Events.LOAD_ERROR));
+    this._iframe.addEventListener('abort', this._success.bind(this, InAppBrowser.Events.LOAD_ERROR));
 
     window.addEventListener('resize', this._resizeCallback);
 };
@@ -352,7 +352,7 @@ IframeBrowser.prototype._resizeContainer = function () {
  * @private
  */
 IframeBrowser.prototype._injectCode = function (code) {
-    var result = this._frame.contentWindow.eval(code);
+    var result = this._iframe.contentWindow.eval(code);
 
     return result ? [result] : [];
 };
@@ -376,13 +376,13 @@ function create(success, fail, args) {
         // open in a new browser tab
         Constructor = SystemBrowser;
         break;
-    case '_blank':
-        Constructor = IframeBrowser;
-        break;
-    default:
-        // "_self" and any other option, use the same tab
+    case '_self':
+        // use the current window
         window.location = args[0];
         return;
+    default:
+        // "_blank" and any other option, use the iframe browser
+        Constructor = IframeBrowser;
     }
 
     return new Constructor(args[0], args[2], success, fail);

--- a/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
+++ b/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
@@ -41,6 +41,8 @@ InAppBrowser.Events = {
     EXIT: 'exit'
 };
 
+InAppBrowser.prototype.getCurrentUrl = function () {};
+
 /**
  * JavaScript implementation of the Native call to show. The simulator browser should be
  * displayed.
@@ -77,7 +79,8 @@ InAppBrowser.prototype.injectStyleFile = function (callback, args) {
  */
 InAppBrowser.prototype._success = function (eventName) {
     this._callbacks.success({
-        type: eventName
+        type: eventName,
+        url: this.getCurrentUrl()
     });
 };
 
@@ -99,6 +102,10 @@ function SystemBrowser(url, options, success, fail) {
 SystemBrowser.prototype = Object.create(InAppBrowser.prototype);
 SystemBrowser.prototype.constructor = SystemBrowser;
 SystemBrowser.prototype.parentClass = InAppBrowser.prototype;
+
+SystemBrowser.prototype.getCurrentUrl = function () {
+    return (this._window ? this._window.location.href : '');
+};
 
 SystemBrowser.prototype.show = function () {
     if (!this._window) {
@@ -142,6 +149,10 @@ IframeBrowser.prototype = Object.create(InAppBrowser.prototype);
 IframeBrowser.prototype.constructor = IframeBrowser;
 IframeBrowser.prototype.parentClass = InAppBrowser.prototype;
 
+IframeBrowser.prototype.getCurrentUrl = function () {
+    return (this._iframe ? this._iframe.src : '');
+};
+
 IframeBrowser.prototype.show = function () {
     if (!this._container) {
         this._createFrame();
@@ -153,16 +164,19 @@ IframeBrowser.prototype.show = function () {
     this._container.style.display = 'block';
 
     this._resizeContainer();
+
+    this._success(InAppBrowser.Events.LOAD_START);
 };
 
 IframeBrowser.prototype.close = function () {
     if (this._container) {
         this._container.parentNode.removeChild(this._container);
         this._container = null;
-        this._iframe = null;
         this._isVisible = false;
 
         this._success(InAppBrowser.Events.EXIT);
+
+        this._iframe = null;
 
         window.removeEventListener('resize', this._resizeCallback);
     }

--- a/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
+++ b/src/plugins/cordova-plugin-inappbrowser/inapp-browser.js
@@ -3,6 +3,8 @@
 // Events taken from cordova-plugin-inappbrowser implementation, and iframe approach
 // based from https://github.com/apache/cordova-plugin-inappbrowser/blob/master/src/browser/InAppBrowserProxy.js
 
+var utils = require('utils');
+
 var _defaultInAppBrowserType = 'iframe';
 
 /**
@@ -13,7 +15,7 @@ var _defaultInAppBrowserType = 'iframe';
  * @constructor
  */
 function InAppBrowser(url, options, success, fail) {
-    this._url = url;
+    this._url = this._prepareUrl(url);
     this._options = {};
     this._callbacks = {
         success: success,
@@ -41,6 +43,19 @@ InAppBrowser.Events = {
     LOAD_STOP: 'loadstop',
     LOAD_ERROR: 'loaderror',
     EXIT: 'exit'
+};
+
+InAppBrowser.prototype._prepareUrl = function (url) {
+    var queryParameter = 'cdvsim-enabled=false',
+        updatedUrl = url;
+
+    if (utils.isSameOriginRequest(url)) {
+        url = utils.parseUrl(url);
+        updatedUrl += (url.search.length > 0) ? '&' : '?';
+        updatedUrl += queryParameter;
+    }
+
+    return updatedUrl;
 };
 
 InAppBrowser.prototype.getCurrentUrl = function () {};

--- a/src/plugins/cordova-plugin-inappbrowser/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-inappbrowser/sim-host-panels.html
@@ -1,0 +1,15 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+
+<cordova-panel id="inappbrowser" caption="InAppBrowser">
+    <cordova-panel-row>
+        <label>Select the default behaviour of InAppBrowser when opening using the <em>_blank</em> target</label>
+    </cordova-panel-row>
+    <cordova-group id="inappbrowser-options">
+        <cordova-radio data-inappbrowser="system">
+            Open in a new window: <em>_system</em> target
+        </cordova-radio>
+        <cordova-radio data-inappbrowser="iframe">
+            Open in a InAppBrowser based on an iframe
+        </cordova-radio>
+    </cordova-group>
+</cordova-panel>

--- a/src/plugins/cordova-plugin-inappbrowser/sim-host.js
+++ b/src/plugins/cordova-plugin-inappbrowser/sim-host.js
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+var db = require('db'),
+    telemetry = require('telemetry-helper');
+
+var baseProps = {
+    plugin: 'cordova-plugin-inappbrowser',
+    panel: 'inappbrowser'
+};
+
+module.exports = function (messages) {
+    var INAPPBROWSER_SELECTION = 'inappbrowser-key';
+    var currentSelection = db.retrieve(INAPPBROWSER_SELECTION) || 'iframe';
+
+    messages.register('inAppBrowserSelected', function (callback) {
+        callback(null, currentSelection);
+    });
+
+    function updateSelection(selection) {
+        currentSelection = selection;
+        db.save(INAPPBROWSER_SELECTION, currentSelection);
+
+        messages.emit('inappbrowser-selected', currentSelection);
+    }
+
+    function initialize() {
+        var optionsGroup = document.getElementById('inappbrowser-options');
+
+        optionsGroup.querySelector('[data-inappbrowser="' + currentSelection + '"]').checked = true;
+
+        optionsGroup.addEventListener('click', function (event) {
+            var target = event.target,
+                selection = target.getAttribute('data-inappbrowser');
+
+            if (currentSelection !== selection) {
+                updateSelection(selection);
+
+                // send telemetry event
+                telemetry.sendUITelemetry(Object.assign({}, baseProps, { control: selection }));
+            }
+        });
+    }
+
+    return {
+        initialize: initialize
+    };
+};

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -41,8 +41,15 @@ function sendHostJsFile(response, hostType) {
 }
 
 function streamAppHostHtml(request, response) {
-    // Always prepare before serving up app HTML file, so app is up-to-date, then create the app-host.js (if it is
-    // out-of-date) so it is ready when it is requested.
+    var filePath = path.join(config.platformRoot, url.parse(request.url).pathname);
+
+    if (request.query && request.query['cdvsim-enabled'] === 'false') {
+        response.sendFile(filePath);
+        return;
+    }
+
+    // Always prepare before serving up app HTML file, so app is up-to-date,
+    // then create the app-host.js (if it is out-of-date) so it is ready when it is requested.
     prepare.prepare().then(function () {
         return simFiles.createAppHostJsFile();
     }).then(function (pluginList) {
@@ -50,7 +57,6 @@ function streamAppHostHtml(request, response) {
         simFiles.validateSimHostPlugins(pluginList);
 
         // Inject plugin simulation app-host <script> references into *.html
-        var filePath = path.join(config.platformRoot, url.parse(request.url).pathname);
         log.log('Injecting app-host into ' + filePath);
         var scriptSources = [
             '/simulator/thirdparty/socket.io-1.2.0.js',

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -20,7 +20,7 @@ html {
 h1 {
     font-family: 'Helvetica Neue', 'Roboto', 'Segoe UI', sans-serif;
     font-size: 16pt;
-    font-weight: bold;    
+    font-weight: bold;
 }
 
 a {
@@ -49,7 +49,7 @@ cordova-panel, cordova-dialog {
     display: block;
 }
 
-body /deep/ .cordova-panel-inner {    
+body /deep/ .cordova-panel-inner {
     border-style: solid;
     border-width: 1px;
     border-color: rgba(0,0,0,0.785);
@@ -62,7 +62,7 @@ body /deep/ .cordova-header {
     padding: 5px 9px;
     position: relative;
     background-color: black;
-    opacity: 0.7; 
+    opacity: 0.7;
     color: rgb(204,204,204);
     font-size: 12px;
     height: 20px;
@@ -212,6 +212,7 @@ body /deep/ select:focus {
 body /deep/ cordova-radio {
     display: flex;
     align-items: center;
+    padding: 2px;
 }
 
 body /deep/ .cordova-panel-row {


### PR DESCRIPTION
Hi! This PR is to add support for the InAppBrowser plugin simulation. It supports all of the available targets for loading a URL using InAppBrowser:
- `_self`: It loads the url in the current window, simulating the navigation to the same WebView
- `_blank`: It creates a div with an iframe and a close control that will show up on top of the main window, taking the full size. This acts as creating a new WebView to navigate to the given URL.
- `_system`: It opens the URL in a new window.
For the case of `_blank` target, all actions are supported, even injecting code into the iframe. But that depends on the URL being loaded on the iframe, for security reasons. So we try to inject JS code and CSS styles as we can, otherwise, an error is logged. This was based on the browser proxy implemented for the plugin.

![screen shot 2016-05-31 at 2 40 28 am](https://cloud.githubusercontent.com/assets/2309921/15664332/412771b6-26d9-11e6-85ef-3d364d47d443.png)

![screen shot 2016-05-31 at 2 41 06 am](https://cloud.githubusercontent.com/assets/2309921/15664335/45816e56-26d9-11e6-8ea1-4a22e87826d8.png)

I want to share this with you to get feedback, in the meantime I will continue testing it with the mobilespec app to improve it.

PS: If you want to try it out, this change #31 needs to be added in order to successfully execute app-host side handlers.
 
Thanks! 