### PR TITLE
Smart prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Where opts is an object with the following properties (all optional):
 * **dir** - the directory to launch from (where it should look for a Cordova project). Defaults to cwd.
 * **simhostui** - the directory containing the UI specific files of the simulation host. Defaults to the bundled simulation host files, found in `src/sim-host/ui`.
 * **livereload** - A boolean. Set to false to disable live reload. Defaults to true.
-* **forceprepare** - A boolean. Set to true to force a `cordova prepare` whenever a file changes during live reload. If this is false, the server attempts to simply copy the changed file to the platform rather than doing a `cordova prepare`. Ignored if live reload is disabled. Defaults to false.
+* **forceprepare** - A boolean. Set to true to force a `cordova prepare` whenever a file changes during live reload. If this is false, the server will simply copy the changed file to the platform rather than doing a `cordova prepare`. Ignored if live reload is disabled. Defaults to false.
 * **corsproxy** - Boolean indicating if XMLHttpRequest is proxied through the simulate server. This is useful for working around CORS issues at development time. Defaults to true.
 * **touchevents** - A boolean. Set to false to disable the simulaton of touch events in App-Host. Defaults to true.
 * **simulationpath** - the directory where temporary simulation files are hosted. Defaults to `projectRoot/simulate`.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chalk": "^1.1.1",
     "cordova-registry-mapper": "^1.1.12",
     "cordova-serve": "^1.0.0",
+    "glob": "^4.5.3",
     "minimist": "^1.2.0",
     "ncp": "^2.0.0",
     "q": "^1.4.1",

--- a/src/server/jsUtils.js
+++ b/src/server/jsUtils.js
@@ -1,0 +1,105 @@
+/**
+ * Returns true if the specified objects are considered similar. Here, similarity is defined as having the same keys,
+ * mapping to equal values (for value properties) or similar values (for arrays or nested objects). Does not correctly
+ * support functions or nested arrays ([1,[2,3]]) - result will be invalid in these scenarios. Offers no protection
+ * against circular objects. By default, order of object properties and array values is not important. 
+ * 
+ * @param {any} o1 The first object.
+ * @param {any} o2 The second object.
+ * @param {boolean=} compareOrder Whether order in object keys and array values should be considered.
+ * 
+ * @returns {boolean} Whether the objects are similar.
+ */
+function compareObjects(o1, o2, compareOrder) {
+    // If either are undefined, return false - don't consider undefined to equal undefined.
+    if (typeof o1 === 'undefined' || typeof o1 === 'undefined') {
+        return false;
+    }
+
+    // Strict comparison first, to compare values or object references.
+    if (o1 === o2) {
+        return true;
+    }
+
+    if (Array.isArray(o1)) {
+        return compareArrays(o1, o2, compareOrder);
+    }
+
+    if (typeof o1 === 'object') {
+        if (typeof o2 !== 'object') {
+            return false;
+        }
+
+        var keys1 = Object.keys(o1);
+        var keys2 = Object.keys(o2);
+
+        return compareArrays(keys1, keys2, compareOrder) &&
+            keys1.every((key) => {
+                return compareObjects(o1[key], o2[key]);
+            });
+    }
+
+    // At this point the objects weren't strictly equal and are not of object type, so return false.
+    return false;
+}
+
+/**
+ * Returns true if the specified arrays are considered similar. Here, similarity is defined as having the same values.
+ * Does not correctly support functions or nested arrays ([1,[2,3]]) - result will be invalid in these scenarios. By
+ * default, order of values is not important ([1,2,3] and [3,2,1] are considered similar).
+ * 
+ * @param {any[]} a1 The first array.
+ * @param {any[]} a2 The second array.
+ * @param {boolean=} compareOrder Whether order of values should be considered.
+ * 
+ * @returns {boolean} Whether the arrays are similar.
+ */
+function compareArrays(a1, a2, compareOrder) {
+    // If either are undefined, return false - don't consider undefined to equal undefined.
+    if (typeof a1 === 'undefined' || typeof a2 === 'undefined') {
+        return false;
+    }
+
+    if (!Array.isArray(a1) || !Array.isArray(a2) || a1.length !== a2.length) {
+        return false;
+    }
+
+    // Strict comparison to compare references.
+    if (a1 === a2) {
+        return true;
+    }
+
+    if (compareOrder) {
+        return a1.every((v, i) => {
+            return v === a2[i];
+        });
+    }
+
+    var itemCounts = {};
+    var isSimilar = true;
+
+    a1.forEach((value) => {
+        if (!itemCounts[value]) {
+            itemCounts[value] = 0;
+        }
+
+        ++itemCounts[value];
+    });
+
+    // Using Array.prototype.find() to break early if needed.
+    a2.find((value) => {
+        if (!itemCounts[value]) {
+            // If this value does not exist or its count is at 0, then a2 has an item that a1 doesn't have.
+            isSimilar = false;
+            return true;    // Return true to break early.
+        }
+
+        --itemCounts[value];
+        return false;   // Return false to keep looking.
+    });
+
+    return isSimilar;
+}
+
+module.exports.compareObjects = compareObjects;
+module.exports.compareArrays = compareArrays;

--- a/src/server/live-reload/live-reload-server.js
+++ b/src/server/live-reload/live-reload-server.js
@@ -8,67 +8,39 @@ var Q = require('q');
 var telemetry = require('../telemetry-helper');
 var Watcher = require('./watcher').Watcher;
 
-var liveReloadEvents = {
-    CAN_REFRESH: 'lr-can-refresh',
-    REFRESH_FILE: 'lr-refresh-file',
-    FULL_RELOAD: 'lr-full-reload'
-};
-
 var socket;
 var watcher;
 
-function onFileChanged(fileRelativePath, filePathFromProjectRoot) {
+function onFileChanged(fileRelativePath, parentDir) {
     fileRelativePath = fileRelativePath.replace(/\\/g, '/');
 
-    // Query the client to determine if this file can be refreshed without reloading the page.
-    var canRefreshDeferred = Q.defer();
+    // Propagate the change to the served platform folder (either via "cordova prepare", or by copying the file
+    // directly).
+    var propagateChangePromise;
 
-    function canRefreshHandler(data) {
-        if (data.fileRelativePath === fileRelativePath) {
-            socket.removeListener(liveReloadEvents.CAN_REFRESH, canRefreshHandler);
-            canRefreshDeferred.resolve(data.canRefresh);
-        }
+    if (config.forcePrepare) {
+        // Sometimes, especially on Windows, prepare will fail because the modified file is locked for a short duration
+        // after modification, so we try to prepare twice.
+        propagateChangePromise = retryAsync(prepare.prepare, 2).then(() => false);
+    } else {
+        var sourceAbsolutePath = path.join(config.projectRoot, parentDir, fileRelativePath);
+        var destAbsolutePath = path.join(config.platformRoot, fileRelativePath);
+
+        propagateChangePromise = copyFile(sourceAbsolutePath, destAbsolutePath).then(() => true);
     }
 
-    socket.on(liveReloadEvents.CAN_REFRESH, canRefreshHandler);
-    socket.emit(liveReloadEvents.CAN_REFRESH, { fileRelativePath: fileRelativePath });
+    // Notify app-host. The delay is needed as a workaround on Windows, because shortly after copying the file, it is
+    // typically locked by the Firewall and can't be correctly sent by the server.
+    propagateChangePromise.delay(125).then((shouldUpdateModifTime) => {
+        var props = { fileType: path.extname(fileRelativePath) };
 
-    var canRefreshFile;
+        if (shouldUpdateModifTime) {
+            prepare.updateTimeStampForFile(fileRelativePath, parentDir);
+        }
 
-    canRefreshDeferred.promise
-        .then(function (canRefresh) {
-            canRefreshFile = canRefresh;
-
-            // Propagate the change to the served platform folder (either via "cordova prepare", or by copying the file directly).
-            if (canRefreshFile) {
-                if (config.forcePrepare) {
-                    // Sometimes, especially on Windows, prepare will fail because the modified file is locked for a short duration after modification, so we try to prepare twice.
-                    return retryAsync(prepare.execCordovaPrepare, 2);
-                }
-
-                var destAbsolutePath = path.join(config.platformRoot, fileRelativePath);
-
-                return copyFile(filePathFromProjectRoot, destAbsolutePath);
-
-            } else {
-                // A full reload is needed, so the simulation server will do a prepare - no need to prepare again here.
-                return Q.resolve();
-            }
-        })
-        // The delay is needed as a workaround on Windows, because shortly after copying the file, it is typically locked by the Firewall and can't be correctly sent by the server.
-        .delay(125).then(function () {
-            var props = { fileType: path.extname(fileRelativePath) };
-
-            if (canRefreshFile) {
-                props.reloadType = 'refresh';
-                socket.emit(liveReloadEvents.REFRESH_FILE, { fileRelativePath: fileRelativePath });
-            } else {
-                props.reloadType = 'full-reload';
-                socket.emit(liveReloadEvents.FULL_RELOAD);
-            }
-
-            telemetry.sendTelemetry('live-reload', props);
-        }).done();
+        socket.emit('lr-file-changed', { fileRelativePath: fileRelativePath });
+        telemetry.sendTelemetry('live-reload', props);
+    }).done();
 }
 
 function copyFile(src, dest) {

--- a/src/server/live-reload/watcher.js
+++ b/src/server/live-reload/watcher.js
@@ -68,9 +68,9 @@ function handleWatcherEvent(root, fileRelativePath) {
     // Make sure the event is for a file, not a directory
     var isWww = root === WWW_ROOT;
     var srcPathPrefix = isWww ? path.join(config.projectRoot, WWW_ROOT) : this.mergesOverridePath;
-    var fileAbsolutePath = path.join(srcPathPrefix, fileRelativePath);
+    var filePathFromProjectRoot = path.join(srcPathPrefix, fileRelativePath);
 
-    if (fs.statSync(fileAbsolutePath).isDirectory()) {
+    if (fs.statSync(filePathFromProjectRoot).isDirectory()) {
         return;
     }
 
@@ -81,7 +81,7 @@ function handleWatcherEvent(root, fileRelativePath) {
 
     // Invoke the file changed callback.
     if (this.fileChangedCallback && typeof this.fileChangedCallback === 'function') {
-        this.fileChangedCallback(fileRelativePath, fileAbsolutePath);
+        this.fileChangedCallback(fileRelativePath, root);
     }
 }
 

--- a/src/server/prepare.js
+++ b/src/server/prepare.js
@@ -1,30 +1,51 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-var exec = require('child_process').exec,
-    Q = require('q'),
-    config = require('./config'),
+var config = require('./config'),
+    exec = require('child_process').exec,
+    fs = require('fs'),
+    glob = require('glob'),
+    jsUtils = require('./jsUtils'),
     log = require('./log'),
-    plugins = require('./plugins');
+    path = require('path'),
+    plugins = require('./plugins'),
+    Q = require('q');
 
-var preparedOnce;
+var previousPrepareStates = {};
 var preparePromise;
 var lastPlatform;
 
+/**
+ * Prepares the project and initializes the simulation plugin list.
+ * 
+ * @param {Object=} currentState (Optional) The current state of the project for caching purposes.
+ */
 function prepare() {
     if (!preparePromise) {
         var d = Q.defer();
+        var currentProjectState;
 
         preparePromise = d.promise;
         lastPlatform = config.platform;
 
-        execCordovaPrepare().finally(function () {
+        getProjectState().then((currentState) => {
+            currentProjectState = currentState;
+
+            if (shouldPrepare(currentProjectState)) {
+                return execCordovaPrepare().then(() => true);
+            }
+
+            return Q(false);
+        }).then((didPrepare) => {
+            if (didPrepare || shouldInitPlugins(currentProjectState)) {
+                saveProjectState(currentProjectState);
+                plugins.initPlugins();
+            }
+
+            d.resolve();
+        }).finally(() => {
             lastPlatform = null;
             preparePromise = null;
-        }).then(function () {
-            preparedOnce = true;
-            plugins.initPlugins();
-            d.resolve();
-        });
+        }).done();
     } else {
         if (config.platform !== lastPlatform) {
             // Sanity check to verify we never queue prepares for different platforms
@@ -33,12 +54,6 @@ function prepare() {
     }
 
     return preparePromise;
-}
-
-function waitOnPrepare() {
-    // Caller doesn't want to continue until we've prepared at least once. If we already have, return immediately,
-    // otherwise launch a prepare.
-    return preparedOnce ? Q.when() : prepare();
 }
 
 function execCordovaPrepare() {
@@ -68,6 +83,119 @@ function execCordovaPrepare() {
     return deferred.promise;
 }
 
+function shouldPrepare(currentState) {
+    // We should prepare if we don't have any info on a previous prepare for the current platform, or if there is a
+    // difference in the list of installed plugins, the merges files or the www files.
+    var currentPlatform = config.platform;
+    var previousState = previousPrepareStates[currentPlatform];
+
+    if (!previousState) {
+        return true;
+    }
+
+    currentState = currentState || getProjectState();
+
+    var pluginsAreTheSame = jsUtils.compareObjects(currentState.pluginList, previousState.pluginList);
+    var filesAreTheSame = jsUtils.compareObjects(currentState.files, previousState.files);
+
+    return !pluginsAreTheSame || !filesAreTheSame;
+}
+
+function shouldInitPlugins(currentState) {
+    // We should init plugins if we don't have any info on a previous prepare for the current platform, or if there is
+    // a difference in the list of installed plugins or debug-host handlers.
+    var currentPlatform = config.platform;
+    var previousState = previousPrepareStates[currentPlatform];
+
+    if (!previousState) {
+        return true;
+    }
+
+    currentState = currentState || getProjectState();
+
+    // Use JSON stringification to compare states. This works because a state is an object that only contains
+    // serializable values, and because the glob module, which is used to read directories recursively, is
+    // deterministic in the order of the files it returns.
+    var pluginsAreTheSame = jsUtils.compareObjects(currentState.pluginList, previousState.pluginList);
+    var debugHandlersAreTheSame = jsUtils.compareObjects(currentState.debugHostHandlers, previousState.debugHostHandlers);
+
+    return !pluginsAreTheSame || !debugHandlersAreTheSame;
+}
+
+function getProjectState() {
+    var currentPlatform = config.platform;
+    var newState = {};
+
+    return Q().then(() => {
+        // Get the list of plugins for the current platform.
+        var pluginsJsonPath = path.join(config.projectRoot, 'plugins', currentPlatform + '.json');
+        return Q.nfcall(fs.readFile, pluginsJsonPath);
+    }).then((fileContent) => {
+        var installedPlugins = {};
+
+        try {
+            installedPlugins = Object.keys(JSON.parse(fileContent.toString())['installed_plugins'] || {});
+        } catch (err) {
+            // For some reason, it was not possible to determine which plugins are installed for the current platform, so
+            // use a dummy value to indicate a "bad state".
+            installedPlugins = ['__unknown__'];
+        }
+
+        newState.pluginList = installedPlugins;
+    }).then(() => {
+        // Get the modification times for project files.
+        var wwwRoot = path.join(config.projectRoot, 'www');
+        var mergesRoot = path.join(config.projectRoot, 'merges', config.platform);
+
+        return Q.all([getMtimeForFiles(wwwRoot), getMtimeForFiles(mergesRoot)]);
+    }).spread((wwwFiles, mergesFiles) => {
+        var files = {};
+
+        files.www = wwwFiles || {};
+        files.merges = mergesFiles || {};
+        newState.files = files;
+
+        // Get information about current debug-host handlers.
+        newState.debugHostHandlers = config.debugHostHandlers || [];
+
+        // Return the new state.
+        return newState;
+    });
+}
+
+function saveProjectState(currentState) {
+    previousPrepareStates[config.platform] = currentState || getProjectState();
+}
+
+function updateTimeStampForFile(fileRelativePath, parentDir) {
+    var previousPlatformState = previousPrepareStates[config.platform];
+    var fileAbsolutePath = path.join(config.projectRoot, parentDir, fileRelativePath);
+
+    if (previousPlatformState && previousPlatformState.files && previousPlatformState.files[parentDir] && previousPlatformState.files[parentDir][fileAbsolutePath]) {
+        previousPlatformState.files[parentDir][fileAbsolutePath] = new Date(fs.statSync(fileAbsolutePath).mtime).getTime();
+    }
+}
+
+function getMtimeForFiles(dir) {
+    var files = {};
+
+    Q.nfcall(glob, '**/*', { cwd: dir }).then((rawFiles) => {
+        var filePromises = [];
+
+        rawFiles.forEach((file) => {
+            file = path.join(dir, file);
+
+            filePromises.push(Q.nfcall(fs.stat, file).then((stats) => {
+                files[file] = new Date(stats.mtime).getTime();
+            }));
+        });
+
+        return Q.all(filePromises);
+    }).then(() => {
+        return files;
+    });
+}
+
 module.exports.prepare = prepare;
-module.exports.waitOnPrepare = waitOnPrepare;
 module.exports.execCordovaPrepare = execCordovaPrepare;
+module.exports.updateTimeStampForFile = updateTimeStampForFile;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -81,7 +81,7 @@ function streamAppHostHtml(request, response) {
 function streamSimHostHtml(request, response) {
     // If we haven't ever prepared, do so before we try to generate sim-host, so we know our list of plugins is up-to-date.
     // Then create sim-host.js (if it is out-of-date) so it is ready when it is requested.
-    prepare.waitOnPrepare().then(function () {
+    prepare.prepare().then(function () {
         return simFiles.createSimHostJsFile();
     }).then(function () {
         // Inject references to simulation HTML files

--- a/src/server/sim-files.js
+++ b/src/server/sim-files.js
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 var browserify = require('browserify'),
-    fs = require('fs'),
-    path = require('path'),
-    Q = require('q'),
-    through = require('through2'),
     config = require('./config'),
     dirs = require('./dirs'),
+    fs = require('fs'),
+    jsUtils = require('./jsUtils'),
     log = require('./log'),
+    path = require('path'),
     plugins = require('./plugins'),
     prepare = require('./prepare'),
-    simSocket = require('./socket');
+    Q = require('q'),
+    simSocket = require('./socket'),
+    through = require('through2');
 
 var pluginSimulationFiles = require('./plugin-files');
 
@@ -56,12 +57,12 @@ function waitOnAppHostJs() {
 
 var appHostJsPromise;
 function createAppHostJsFile() {
-    appHostJsPromise = appHostJsPromise || prepare.waitOnPrepare().then(function () {
-            return createHostJsFile(appHost, ['js', 'handlers', 'clobbers']);
-        }).then(function (pluginList) {
-            appHostJsPromise = null;
-            return pluginList;
-        });
+    appHostJsPromise = appHostJsPromise || prepare.prepare().then(function () {
+        return createHostJsFile(appHost, ['js', 'handlers', 'clobbers']);
+    }).then(function (pluginList) {
+        appHostJsPromise = null;
+        return pluginList;
+    });
 
     return appHostJsPromise;
 }
@@ -73,7 +74,7 @@ function validatePlugins(hostType, pluginList) {
     }
 
     var cache = loadJsonFile(jsonFile);
-    if (!compareObjects(cache.plugins, pluginList)) {
+    if (!jsUtils.compareObjects(cache.plugins, pluginList)) {
         return false;
     }
 
@@ -103,7 +104,7 @@ function createHostJsFile(hostType, scriptTypes, pluginList) {
 
     var scriptDefs = createScriptDefs(hostType, scriptTypes);
 
-    var b = browserify({paths: getBrowserifySearchPaths(hostType), debug: true});
+    var b = browserify({ paths: getBrowserifySearchPaths(hostType), debug: true });
     b.transform(function (file) {
         if (file === filePath) {
             var data = '';
@@ -129,7 +130,7 @@ function createHostJsFile(hostType, scriptTypes, pluginList) {
 
     // Include common modules
     getCommonModules(hostType).forEach(function (module) {
-        b.require(module.file, {expose: module.name});
+        b.require(module.file, { expose: module.name });
     });
 
     var pluginTemplate = '\'%PLUGINID%\': require(\'%EXPOSEID%\')';
@@ -142,7 +143,7 @@ function createHostJsFile(hostType, scriptTypes, pluginList) {
                 scriptDef.code.push(pluginTemplate
                     .replace(/%PLUGINID%/g, pluginId)
                     .replace(/%EXPOSEID%/g, exposeId));
-                b.require(pluginScriptFile, {expose: exposeId});
+                b.require(pluginScriptFile, { expose: exposeId });
             }
         });
     });
@@ -157,7 +158,7 @@ function createHostJsFile(hostType, scriptTypes, pluginList) {
 
     outputFileStream.on('finish', function () {
         builtOnce[hostType] = true;
-        fs.writeFileSync(jsonFile, JSON.stringify({plugins: pluginList, files: fileInfo}));
+        fs.writeFileSync(jsonFile, JSON.stringify({ plugins: pluginList, files: fileInfo }));
         d.resolve(pluginList);
     });
     outputFileStream.on('error', function (error) {
@@ -216,41 +217,14 @@ function getCommonModules(hostType) {
                 if (fs.existsSync(searchPath)) {
                     fs.readdirSync(searchPath).forEach(function (file) {
                         if (path.extname(file) === '.js') {
-                            _commonModules[hostType].push({name: path.basename(file, '.js'), file: path.join(searchPath, file)});
+                            _commonModules[hostType].push({ name: path.basename(file, '.js'), file: path.join(searchPath, file) });
                         }
                     });
                 }
             });
         });
     }
-    return hostType? _commonModules[hostType] : _commonModules;
-}
-
-function compareObjects(o1, o2) {
-    // If either are undefined, return false - don't consider undefined to equal undefined.
-    if (typeof o1 === 'undefined' || typeof o1 === 'undefined') {
-        return false;
-    }
-
-    if (Array.isArray(o1)) {
-        if (!Array.isArray(o2)) {
-            return false;
-        }
-        // Simple array comparison - expects same order and only scalar values
-        return o1.length === o2.length && o1.every(function (v, i) {
-                return v === o2[i];
-            });
-    }
-
-    var keys1 = Object.keys(o1);
-    var keys2 = Object.keys(o2);
-
-    return compareObjects(keys1, keys2) &&
-        compareObjects(keys1.map(function (key) {
-            return o1[key];
-        }), keys2.map(function (key) {
-            return o2[key];
-        }));
+    return hostType ? _commonModules[hostType] : _commonModules;
 }
 
 function getHostJsFile(hostType) {

--- a/src/server/socket.js
+++ b/src/server/socket.js
@@ -117,6 +117,7 @@ function init(server) {
 
             if (data && data.handlers) {
                 socket.on('disconnect', function () {
+                    log.log('Debug-host disconnected.');
                     config.debugHostHandlers = null;
                 });
                 config.debugHostHandlers = data.handlers


### PR DESCRIPTION
Fixes #37.

More context on the 2 big changes:

**Prepare**
Currently, every time an HTML file is served to app-host, the server forces a prepare. This adds between 0.5 and 1 second of delay on every navigation - including when live reloading changes.

These changes add a "project state" verification to the prepare module to prevent unnecessary prepares. The prepare module stores the list of plugins, project files and debug-host handlers and uses that to determine whether to prepare or not.

**Live reload**
In the existing live reload server, app-host must be queried every time there is a changed file to ask it whether that file can be refreshed without a full page reload. The reason it had to do that was to prevent preparing twice in a row in case the app required a full reload and the user had specified `--forceprepare`.

With these changes to the prepare module, it no longer matters if the live reload server requests an extra prepare - the prepare module is now smart enough to not prepare if it is not needed. So, that 3-way messenging between the live reload server and app-host can be entirely removed.