### PR TITLE
Commenting out unsupported camera options

### DIFF
--- a/src/plugins/cordova-plugin-camera/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-camera/sim-host-panels.html
@@ -2,9 +2,9 @@
 
 <cordova-panel id="camera" caption="Camera">
     <cordova-group id="camera-options">
-        <cordova-radio id="camera-host">Use host system camera</cordova-radio>
+        <!--<cordova-radio id="camera-host">Use host system camera</cordova-radio>-->
         <cordova-radio id="camera-prompt" checked="true">Prompt me for a file</cordova-radio>
-        <cordova-radio id="camera-sample">Use built-in sample file</cordova-radio>
+        <!--<cordova-radio id="camera-sample">Use built-in sample file</cordova-radio>-->
         <cordova-panel-row>
             <cordova-radio id="camera-file" inline="true">Use this file:</cordova-radio>
             <cordova-button id="camera-choose-filename">Choose File

--- a/src/plugins/cordova-plugin-camera/sim-host.js
+++ b/src/plugins/cordova-plugin-camera/sim-host.js
@@ -12,9 +12,10 @@ module.exports = function (messages) {
     var filenameInput, dialogFilenameInput, dialogImg;
 
     messages.register('takePicture', function (args, callback) {
-        if (document.getElementById('camera-host').checked) {
+        /*if (document.getElementById('camera-host').checked) {
             window.alert('Not supported');
-        } else if (document.getElementById('camera-prompt').checked) {
+        } else*/
+        if (document.getElementById('camera-prompt').checked) {
             dialog.showDialog('camera-choose-image', function (msg) {
                 if (msg === 'showing') {
                     // Not we use .onclick etc here rather than addEventListener() to ensure we replace any existing
@@ -29,9 +30,11 @@ module.exports = function (messages) {
                     };
                 }
             });
-        } else if (document.getElementById('camera-sample').checked) {
+        }
+        /*else if (document.getElementById('camera-sample').checked) {
             window.alert('Not supported');
-        } else if (document.getElementById('camera-file').checked) {
+        }*/
+        else if (document.getElementById('camera-file').checked) {
             createArrayBuffer(filenameInput, callback);
         }
     });
@@ -82,9 +85,9 @@ module.exports = function (messages) {
                 }
             }
 
-            document.getElementById('camera-host').onclick = handleRadioClick.bind(this, 'camera-host');
+            //document.getElementById('camera-host').onclick = handleRadioClick.bind(this, 'camera-host');
             document.getElementById('camera-prompt').onclick = handleRadioClick.bind(this, 'camera-prompt');
-            document.getElementById('camera-sample').onclick = handleRadioClick.bind(this, 'camera-sample');
+            //document.getElementById('camera-sample').onclick = handleRadioClick.bind(this, 'camera-sample');
             document.getElementById('camera-file').onclick = handleRadioClick.bind(this, 'camera-file');
         }
     };


### PR DESCRIPTION
Commenting out code related to the currently unsupported camera options (host system camera and built-in default image).

The reason why I don't want to delete the code is that we will very likely re-enable these options soon, and the commented code will provide an easier starting point.

Tracking for this has been opened in #47.