### PR TITLE
Replacing textContent property with value property name.

### DIFF
--- a/src/plugins/cordova-plugin-battery-status/sim-host.js
+++ b/src/plugins/cordova-plugin-battery-status/sim-host.js
@@ -18,7 +18,7 @@ module.exports = function (message) {
             pluggedCheckbox = document.getElementById('is-plugged');
 
         function updateBatteryLevelText(level) {
-            labelBatteryLevel.textContent = level + '%';
+            labelBatteryLevel.value = level + '%';
         }
 
         // Initialize the UI with the values of isPlugged and battery level.

--- a/src/plugins/cordova-plugin-geolocation/sim-host.js
+++ b/src/plugins/cordova-plugin-geolocation/sim-host.js
@@ -177,7 +177,7 @@ module.exports = function (messages) {
                 var headingDeg  = parseFloat(heading.value),
                     headingText = navUtils.getDirection(headingDeg);
 
-                headingLabel.textContent = headingText;
+                headingLabel.value = headingText;
                 headingMapLabel.innerHTML = headingText + '</br>' + headingDeg + '&deg;';
 
                 var style = ['-webkit-transform', '-ms-transform', '-moz-transform', '-o-transform', 'transform'].map(function (prop) {
@@ -209,7 +209,7 @@ module.exports = function (messages) {
                 accuracy.value = positionInfo.accuracy;
                 altitudeAccuracy.value = positionInfo.altitudeAccuracy;
 
-                delay.value = document.getElementById(GEO_OPTIONS.DELAY_LABEL).textContent = geo.delay || 0;
+                delay.value = document.getElementById(GEO_OPTIONS.DELAY_LABEL).value = geo.delay || 0;
                 if (geo.timeout) {
                     timeout.checked = true;
                 }
@@ -456,12 +456,12 @@ module.exports = function (messages) {
 
             document.querySelector('#' + GEO_OPTIONS.DELAY).addEventListener('change', function () {
                 updateGeo();
-                delayLabel.textContent = delay.value;
+                delayLabel.value = delay.value;
             });
 
             document.querySelector('#' + GEO_OPTIONS.DELAY).addEventListener('input', function () {
                 updateGeo();
-                delayLabel.textContent = delay.value;
+                delayLabel.value = delay.value;
             });
 
             document.querySelector('#' + GEO_OPTIONS.TIMEOUT).addEventListener('click', function () {

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -50,7 +50,6 @@ function initialize() {
 
     registerCustomElement('cordova-item', function () {
         this.classList.add('cordova-group');
-        var item = this;
         this.addEventListener('click', function (e) {
             if (e.target === this) {
                 // If the click target is our self, the only thing that could have been clicked is the delete icon.
@@ -120,7 +119,7 @@ function initialize() {
     });
 
     registerCustomElement('cordova-label', {
-        textContent: {
+        value: {
             set: function (value) {
                 setValueSafely(this.shadowRoot.querySelector('label'), 'textContent', value);
             },


### PR DESCRIPTION
Hi! This PR is a workaround proposal for an issue that I'm having with the `cordova-label` web component on old versions of chromium: the `textContent` property of the component is not re-defined so we never end up modifying the  `label` element inside the `shadowRoot`. 