### PR TITLE
Allowing project reinit.

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -13,7 +13,7 @@ var simulationFilePath;
     { name: 'liveReload' },
     { name: 'platform' },
     { name: 'platformRoot' },
-    { name: 'projectRoot', single: true },
+    { name: 'projectRoot' },
     { name: 'server', optional: true },
     { name: 'simHostOptions' },
     { name: 'simulationFilePath' },


### PR DESCRIPTION
I made a change in our integration code and I started hitting the "Cannot reinitialize..." exception. Given that we can close and restart the simulation server programmatically via the API, I think we should allow project path re-initialization.