### PR TITLE
Updating usages of ES6 features for backward compatibility with older node versions

### DIFF
--- a/src/app-host/live-reload-client.js
+++ b/src/app-host/live-reload-client.js
@@ -54,7 +54,7 @@ module.exports.start = function (sock) {
      */
     function urlMatchesPath(url, fileRelativePath) {
         return localUrlPrefixes.some(function (prefix) {
-            return (prefix + fileRelativePath === url);
+            return (prefix + fileRelativePath) === url;
         });
     }
 
@@ -109,7 +109,6 @@ module.exports.start = function (sock) {
      */
     function onFileChanged(fileRelativePath) {
         var associatedNodes = findDomNodesForFilePath(fileRelativePath);
-        var canRefresh = false;
 
         if (associatedNodes.length) {
             refreshFile(fileRelativePath, associatedNodes);

--- a/src/app-host/live-reload-client.js
+++ b/src/app-host/live-reload-client.js
@@ -53,15 +53,9 @@ module.exports.start = function (sock) {
      * @returns {boolean} Whether the URL points to the modified file from the server.
      */
     function urlMatchesPath(url, fileRelativePath) {
-        var isMatch = false;
-
-        localUrlPrefixes.find(function (prefix) {
-            isMatch = prefix + fileRelativePath === url;
-
-            return isMatch;
+        return localUrlPrefixes.some(function (prefix) {
+            return (prefix + fileRelativePath === url);
         });
-
-        return isMatch;
     }
 
     /**
@@ -109,7 +103,7 @@ module.exports.start = function (sock) {
     /**
      * Determines whether the changes form the specified file can be applied to the app without a full page reload.
      * Then, based on that, either updates the reference attribute of the appropriate node, or does a full page
-     * reload. 
+     * reload.
      *
      * @param {String} fileRelativePath The URL of the file that changed, relative to the webRoot.
      */

--- a/src/server/jsUtils.js
+++ b/src/server/jsUtils.js
@@ -2,17 +2,17 @@
  * Returns true if the specified objects are considered similar. Here, similarity is defined as having the same keys,
  * mapping to equal values (for value properties) or similar values (for arrays or nested objects). Does not correctly
  * support functions or nested arrays ([1,[2,3]]) - result will be invalid in these scenarios. Offers no protection
- * against circular objects. By default, order of object properties and array values is not important. 
- * 
+ * against circular objects. By default, order of object properties and array values is not important.
+ *
  * @param {any} o1 The first object.
  * @param {any} o2 The second object.
  * @param {boolean=} compareOrder Whether order in object keys and array values should be considered.
- * 
+ *
  * @returns {boolean} Whether the objects are similar.
  */
 function compareObjects(o1, o2, compareOrder) {
     // If either are undefined, return false - don't consider undefined to equal undefined.
-    if (typeof o1 === 'undefined' || typeof o1 === 'undefined') {
+    if (typeof o1 === 'undefined' || typeof o2 === 'undefined') {
         return false;
     }
 
@@ -34,7 +34,7 @@ function compareObjects(o1, o2, compareOrder) {
         var keys2 = Object.keys(o2);
 
         return compareArrays(keys1, keys2, compareOrder) &&
-            keys1.every((key) => {
+            keys1.every(function (key) {
                 return compareObjects(o1[key], o2[key]);
             });
     }
@@ -47,11 +47,11 @@ function compareObjects(o1, o2, compareOrder) {
  * Returns true if the specified arrays are considered similar. Here, similarity is defined as having the same values.
  * Does not correctly support functions or nested arrays ([1,[2,3]]) - result will be invalid in these scenarios. By
  * default, order of values is not important ([1,2,3] and [3,2,1] are considered similar).
- * 
+ *
  * @param {any[]} a1 The first array.
  * @param {any[]} a2 The second array.
  * @param {boolean=} compareOrder Whether order of values should be considered.
- * 
+ *
  * @returns {boolean} Whether the arrays are similar.
  */
 function compareArrays(a1, a2, compareOrder) {
@@ -70,7 +70,7 @@ function compareArrays(a1, a2, compareOrder) {
     }
 
     if (compareOrder) {
-        return a1.every((v, i) => {
+        return a1.every(function (v, i) {
             return v === a2[i];
         });
     }
@@ -78,7 +78,7 @@ function compareArrays(a1, a2, compareOrder) {
     var itemCounts = {};
     var isSimilar = true;
 
-    a1.forEach((value) => {
+    a1.forEach(function (value) {
         if (!itemCounts[value]) {
             itemCounts[value] = 0;
         }
@@ -86,8 +86,8 @@ function compareArrays(a1, a2, compareOrder) {
         ++itemCounts[value];
     });
 
-    // Using Array.prototype.find() to break early if needed.
-    a2.find((value) => {
+    // Using Array.prototype.some() to break early if needed.
+    a2.some(function (value) {
         if (!itemCounts[value]) {
             // If this value does not exist or its count is at 0, then a2 has an item that a1 doesn't have.
             isSimilar = false;

--- a/src/server/live-reload/live-reload-server.js
+++ b/src/server/live-reload/live-reload-server.js
@@ -21,17 +21,21 @@ function onFileChanged(fileRelativePath, parentDir) {
     if (config.forcePrepare) {
         // Sometimes, especially on Windows, prepare will fail because the modified file is locked for a short duration
         // after modification, so we try to prepare twice.
-        propagateChangePromise = retryAsync(prepare.prepare, 2).then(() => false);
+        propagateChangePromise = retryAsync(prepare.prepare, 2).then(function () {
+            return false;
+        });
     } else {
         var sourceAbsolutePath = path.join(config.projectRoot, parentDir, fileRelativePath);
         var destAbsolutePath = path.join(config.platformRoot, fileRelativePath);
 
-        propagateChangePromise = copyFile(sourceAbsolutePath, destAbsolutePath).then(() => true);
+        propagateChangePromise = copyFile(sourceAbsolutePath, destAbsolutePath).then(function () {
+            return true;
+        });
     }
 
     // Notify app-host. The delay is needed as a workaround on Windows, because shortly after copying the file, it is
     // typically locked by the Firewall and can't be correctly sent by the server.
-    propagateChangePromise.delay(125).then((shouldUpdateModifTime) => {
+    propagateChangePromise.delay(125).then(function (shouldUpdateModifTime) {
         var props = { fileType: path.extname(fileRelativePath) };
 
         if (shouldUpdateModifTime) {

--- a/src/server/plugins.js
+++ b/src/server/plugins.js
@@ -165,7 +165,7 @@ function shouldUsePluginWithDebugHost(pluginPath, pluginAddedToProject) {
     pluginAddedToProject = !!pluginAddedToProject;
 
     // Check whether the plugin defines some debug-host requirements.
-    var debugHostFilePath = path.join(pluginPath, pluginSimulationFiles['debug-host']['debug-host'])
+    var debugHostFilePath = path.join(pluginPath, pluginSimulationFiles['debug-host']['debug-host']);
 
     if (!fs.existsSync(debugHostFilePath)) {
         // Plugin doesn't have any requirements for debug-host. Always use the plugin if it was added to the project.

--- a/src/server/prepare.js
+++ b/src/server/prepare.js
@@ -27,22 +27,24 @@ function prepare() {
         preparePromise = d.promise;
         lastPlatform = config.platform;
 
-        getProjectState().then((currentState) => {
+        getProjectState().then(function (currentState) {
             currentProjectState = currentState;
 
             if (shouldPrepare(currentProjectState)) {
-                return execCordovaPrepare().then(() => true);
+                return execCordovaPrepare().then(function () {
+                    return true;
+                });
             }
 
             return Q(false);
-        }).then((didPrepare) => {
+        }).then(function (didPrepare) {
             if (didPrepare || shouldInitPlugins(currentProjectState)) {
                 saveProjectState(currentProjectState);
                 plugins.initPlugins();
             }
 
             d.resolve();
-        }).finally(() => {
+        }).finally(function () {
             lastPlatform = null;
             preparePromise = null;
         }).done();
@@ -126,11 +128,11 @@ function getProjectState() {
     var currentPlatform = config.platform;
     var newState = {};
 
-    return Q().then(() => {
+    return Q().then(function () {
         // Get the list of plugins for the current platform.
         var pluginsJsonPath = path.join(config.projectRoot, 'plugins', currentPlatform + '.json');
         return Q.nfcall(fs.readFile, pluginsJsonPath);
-    }).then((fileContent) => {
+    }).then(function (fileContent) {
         var installedPlugins = {};
 
         try {
@@ -142,13 +144,13 @@ function getProjectState() {
         }
 
         newState.pluginList = installedPlugins;
-    }).then(() => {
+    }).then(function () {
         // Get the modification times for project files.
         var wwwRoot = path.join(config.projectRoot, 'www');
         var mergesRoot = path.join(config.projectRoot, 'merges', config.platform);
 
         return Q.all([getMtimeForFiles(wwwRoot), getMtimeForFiles(mergesRoot)]);
-    }).spread((wwwFiles, mergesFiles) => {
+    }).spread(function (wwwFiles, mergesFiles) {
         var files = {};
 
         files.www = wwwFiles || {};
@@ -179,19 +181,19 @@ function updateTimeStampForFile(fileRelativePath, parentDir) {
 function getMtimeForFiles(dir) {
     var files = {};
 
-    Q.nfcall(glob, '**/*', { cwd: dir }).then((rawFiles) => {
+    Q.nfcall(glob, '**/*', { cwd: dir }).then(function (rawFiles) {
         var filePromises = [];
 
-        rawFiles.forEach((file) => {
+        rawFiles.forEach(function (file) {
             file = path.join(dir, file);
 
-            filePromises.push(Q.nfcall(fs.stat, file).then((stats) => {
+            filePromises.push(Q.nfcall(fs.stat, file).then(function (stats) {
                 files[file] = new Date(stats.mtime).getTime();
             }));
         });
 
         return Q.all(filePromises);
-    }).then(() => {
+    }).then(function () {
         return files;
     });
 }

--- a/src/server/socket.js
+++ b/src/server/socket.js
@@ -164,23 +164,19 @@ function invalidateSimHost() {
 }
 
 function closeConnections() {
-  var hostType,
-      socket;
-  for (hostType in hostSockets) {
-    if (hostSockets.hasOwnProperty(hostType)) {
-      socket = hostSockets[hostType];
-      if (socket) {
-        socket.disconnect(true);
-      }
+    Object.keys(hostSockets).forEach(function (hostType) {
+        var socket = hostSockets[hostType];
+        if (socket) {
+            socket.disconnect(true);
+        }
+    });
+
+    if (io) {
+        io.close();
+        io = null;
     }
-  }
 
-  if (io) {
-    io.close();
-    io = null;
-  }
-
-  reset();
+    reset();
 }
 
 module.exports.init = init;

--- a/src/server/socket.js
+++ b/src/server/socket.js
@@ -131,7 +131,7 @@ function init(server) {
                     log.log('Debug-host disconnected.');
                     config.debugHostHandlers = null;
                 });
-                config.debugHostHandlers = data.handlers
+                config.debugHostHandlers = data.handlers;
             }
 
             handlePendingEmits(DEBUG_HOST);

--- a/src/sim-host/protocol/socket.js
+++ b/src/sim-host/protocol/socket.js
@@ -83,6 +83,7 @@ module.exports.initialize = function (pluginHandlers, services) {
         registerSimHost();
     }
 };
+
 module.exports.notifyPluginsReady = function () {
     telemetry.registerPluginServices(serviceToPluginMap);
 
@@ -91,4 +92,4 @@ module.exports.notifyPluginsReady = function () {
     } else {
         registerOnInitialize = true;
     }
-}
+};


### PR DESCRIPTION
This PR includes:
- Updating usages of arrow functions to regular ES5 functions
- Replacing usages of `Array.prototype.find` with `Array.prototype.some`

An extra: updating implementation of `server/socket` `closeConnections` function as suggested in previous PR.

This address #55 

Thanks!