### PR TITLE
Geolocation simulation widget changes

### DIFF
--- a/src/modules/sim-constants.js
+++ b/src/modules/sim-constants.js
@@ -86,7 +86,7 @@ module.exports = {
             'GPXMULTIPLIER': 'geo-gpxmultiplier-select',
             'GPXREPLAYSTATUS': 'geo-gpxreplaystatus'
         },
-        'MAP_ZOOM_MAX': 21,
+        'MAP_ZOOM_MAX': 18,
         'MAP_ZOOM_MIN': 0,
         'MAP_ZOOM_LEVEL_CONTAINER': 'geo-map-zoomlevel-value',
         'MAP_ZOOM_KEY': 'geo-map-zoom-key',

--- a/src/plugins/cordova-plugin-geolocation/app-host-clobbers.js
+++ b/src/plugins/cordova-plugin-geolocation/app-host-clobbers.js
@@ -186,6 +186,10 @@ module.exports = function (messages, exec) {
                 timers[id].timer = false;
                 exec(null, null, 'Geolocation', 'clearWatch', [id]);
             }
+        },
+
+        getPermission: function (success, fail, args) {
+            success();
         }
     };
 

--- a/src/plugins/cordova-plugin-geolocation/sim-host-handlers.js
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-handlers.js
@@ -47,6 +47,9 @@ module.exports = function (messages) {
                 if (success && typeof (success) === 'function') {
                     success();
                 }
+            },
+            getPermission: function (success, fail, args) {
+                success();
             }
         }
     };

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -38,17 +38,17 @@
         </section>
     </cordova-panel-row>
 
-    <cordova-text-entry label="Latitude" id="geo-latitude"></cordova-text-entry>
-    <cordova-text-entry label="Longitude" id="geo-longitude"></cordova-text-entry>
-    <cordova-text-entry label="Altitude" id="geo-altitude"></cordova-text-entry>
-    <cordova-text-entry label="Accuracy" id="geo-accuracy"></cordova-text-entry>
-    <cordova-text-entry label="Altitude accuracy" id="geo-altitude-accuracy"></cordova-text-entry>
+    <cordova-number-entry label="Latitude" id="geo-latitude"></cordova-number-entry>
+    <cordova-number-entry label="Longitude" id="geo-longitude"></cordova-number-entry>
+    <cordova-number-entry label="Altitude" id="geo-altitude"></cordova-number-entry>
+    <cordova-number-entry label="Accuracy" id="geo-accuracy"></cordova-number-entry>
+    <cordova-number-entry label="Altitude accuracy" id="geo-altitude-accuracy"></cordova-number-entry>
     <cordova-panel-row>
         <cordova-label label="Heading"></cordova-label>
         <cordova-label label="N" id="geo-heading-label"></cordova-label>
         <input id="geo-heading" type="range" value="0" min="0" max="359.5" step="0.5" style="width:112px;">
     </cordova-panel-row>
-    <cordova-text-entry label="Speed" id="geo-speed"></cordova-text-entry>
+    <cordova-number-entry label="Speed" id="geo-speed"></cordova-number-entry>
     <cordova-panel-row>
         <cordova-label label="GPS Delay (seconds)"></cordova-label>
         <cordova-label label="0" id="geo-delay-label"></cordova-label>

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -12,6 +12,32 @@
             margin-left: auto;
         }
     </style>
+    <!-- Note that this needs to be a cordova-group not a cordova-panel-row as the flex box arranging of the latter
+     screws up sizing of the map box in Firefox -->
+    <cordova-group>
+        <div class='geo-box'>
+            <div class='geo-content'>
+                <div id="geo-map-container"></div>
+                <div id="geo-map-marker"></div>
+                <div id="geo-map-direction">
+                    <div id="geo-map-arrow"></div>
+                    <div id="geo-map-direction-label"></div>
+                </div>
+                <div id="geo-gpxreplaystatus"></div>
+            </div>
+        </div>
+    </cordova-group>
+    <cordova-panel-row>
+        <section>
+        <cordova-button id="geo-map-zoom-decrease" style="min-width:0;">-</cordova-button>
+        <cordova-button id="geo-map-zoom-increase" style="min-width:0;">+</cordova-button>
+        </section>
+        <section class="geo-map-zoomlevel">
+            Zoom Level:&nbsp;
+            <span id="geo-map-zoomlevel-value"></span>
+        </section>
+    </cordova-panel-row>
+
     <cordova-text-entry label="Latitude" id="geo-latitude"></cordova-text-entry>
     <cordova-text-entry label="Longitude" id="geo-longitude"></cordova-text-entry>
     <cordova-text-entry label="Altitude" id="geo-altitude"></cordova-text-entry>
@@ -55,32 +81,6 @@
                 <option value="64">64x</option>
                 <option value="128">128x</option>
             </cordova-combo>
-        </section>
-    </cordova-panel-row>
-
-    <!-- Note that this needs to be a cordova-group not a cordova-panel-row as the flex box arranging of the latter
-     screws up sizing of the map box in Firefox -->
-    <cordova-group>
-        <div class='geo-box'>
-            <div class='geo-content'>
-                <div id="geo-map-container"></div>
-                <div id="geo-map-marker"></div>
-                <div id="geo-map-direction">
-                    <div id="geo-map-arrow"></div>
-                    <div id="geo-map-direction-label"></div>
-                </div>
-                <div id="geo-gpxreplaystatus"></div>
-            </div>
-        </div>
-    </cordova-group>
-    <cordova-panel-row>
-        <section>
-        <cordova-button id="geo-map-zoom-decrease" style="min-width:0;">-</cordova-button>
-        <cordova-button id="geo-map-zoom-increase" style="min-width:0;">+</cordova-button>
-        </section>
-        <section class="geo-map-zoomlevel">
-            Zoom Level:&nbsp;
-            <span id="geo-map-zoomlevel-value"></span>
         </section>
     </cordova-panel-row>
 </cordova-panel>

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -152,6 +152,45 @@ function initialize() {
         this.classList.add('cordova-group');
     }, 'input');
 
+    registerCustomElement('cordova-number-entry', {
+        value: {
+            set: function (value) {
+                setValueSafely(this.shadowRoot.querySelector('input'), 'value', value);
+            },
+
+            get: function () {
+                return this.shadowRoot.querySelector('input').value;
+            }
+        },
+        disabled: {
+            set: function (value) {
+                setValueSafely(this.shadowRoot.querySelector('input'), 'disabled', value);
+            }
+        }
+    }, function () {
+        this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');
+        this.classList.add('cordova-panel-row');
+        this.classList.add('cordova-group');
+
+        var input = this.shadowRoot.querySelector('input');
+
+        var maxValue = this.getAttribute('max'),
+            minValue = this.getAttribute('min'),
+            step = this.getAttribute('step');
+
+        if (maxValue !== null) {
+            input.setAttribute('max', maxValue);
+        }
+
+        if (minValue !== null) {
+            input.setAttribute('min', minValue);
+        }
+
+        if (step !== null) {
+            input.setAttribute('step', step);
+        }
+    }, 'input');
+
     registerCustomElement('cordova-labeled-value', {
         label: {
             set: function (value) {

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -155,7 +155,8 @@ body /deep/ select {
 }
 
 body /deep/ select,
-body /deep/ input[type^=text], input[type^=number] {
+body /deep/ input[type^=text],
+body /deep/ input[type^=number], input[type^=number] {
     padding: 5px;
 }
 

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -74,6 +74,11 @@
         <input id="cordova-text-entry-template-input" class="cordova-widget cordova-state-default" type="text">
     </template>
 
+    <template id="cordova-number-entry-template">
+        <label for="cordova-number-entry-template-input"></label>
+        <input id="cordova-number-entry-template-input" class="cordova-state-default" type="number">
+    </template>
+
     <template id="cordova-button-template">
         <button class="cordova-widget cordova-state-default">
             <span><content></content></span>


### PR DESCRIPTION
Hi! This PR includes the following:
- Move the map container to render first than the inputs to update the longitude, latitude etc values. The motivation was that maybe the users are more likely to interact more with the map itself, and advanced users or those who has specific coordinates, will use then the inputs. I'm open to suggestions :)
- Implement the `Geolocation.getPermission` exec handler: always executes the success callback. Fix for #70 
- Create a new web component, `cordova-number-entry` that wraps an input type number.
- Update the geolocation inputs fields to use the `cordova-number-entry` for the values that must be numbers.
- Fix the right maximum zoom value supported by OpenLayers, it seems to be 18, otherwise a greater number will not update the map zoom. Fix for #62 

![screen shot 2016-06-10 at 2 17 17 am](https://cloud.githubusercontent.com/assets/2309921/15954799/a34dd3a0-2eb1-11e6-8321-3c68cee84f8e.png)

cc @guillaumejenkins @dlebu @busykai 

Thanks!