### PR TITLE
Fixed exec panel breaking when deleting the 'No values saved' item

### DIFF
--- a/src/plugins/exec/sim-host-panels.html
+++ b/src/plugins/exec/sim-host-panels.html
@@ -1,5 +1,8 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
 <cordova-panel id="exec-panel" caption="Persisted Exec Calls">
+    <cordova-panel-row>
+        <cordova-label id="empty-label" class="cordova-hidden" label="No values saved"></cordova-label>
+    </cordova-panel-row>
     <cordova-item-list id="exec-list" max-length="10"></cordova-item-list>
 </cordova-panel>

--- a/src/plugins/exec/sim-host.js
+++ b/src/plugins/exec/sim-host.js
@@ -6,18 +6,25 @@
 var savedSims = require('./saved-sims');
 var event = require('event');
 
+var emptyLabel;
+var execList;
+
 module.exports = {
     initialize: function () {
         var sims = savedSims.sims;
 
-        var execList = document.getElementById('exec-list');
+        emptyLabel = document.getElementById('empty-label');
+        execList = document.getElementById('exec-list');
         execList.addEventListener('itemremoved', function (e) {
             savedSims.removeSim(e.detail.itemIndex);
-            addEmptyItem();
+
+            if (!savedSims.sims.length) {
+                showEmptyLabel();
+            }
         });
 
         event.on('saved-sim-added', function (sim) {
-            removeEmptyItem();
+            hideEmptyLabel();
             execList.addItem(cordovaItemFromSim(sim));
         });
 
@@ -27,7 +34,7 @@ module.exports = {
             });
         } else {
             // Create a "No values saved" item
-            addEmptyItem();
+            showEmptyLabel();
         }
     }
 };
@@ -51,36 +58,13 @@ function cordovaItemFromSim(sim) {
     return cordovaItem;
 }
 
-function createEmptyItem() {
-    var labeledValue = new CordovaLabeledValue();
-    labeledValue.label = 'No values saved';
-    labeledValue.value = '';
-    var cordovaItem = new CordovaItem();
-    cordovaItem.appendChild(labeledValue);
-    return cordovaItem;
+function showEmptyLabel() {
+    emptyLabel.classList.remove('cordova-hidden');
+    execList.classList.add('cordova-hidden');
 }
 
-var hasEmptyItem = false;
-function addEmptyItem() {
-    if (hasEmptyItem) {
-        return;
-    }
-
-    var execList = document.getElementById('exec-list');
-    var sims = savedSims.sims;
-    if (sims.length === 0) {
-        execList.addItem(createEmptyItem());
-        hasEmptyItem = true;
-    }
-}
-
-function removeEmptyItem() {
-    if (!hasEmptyItem) {
-        return;
-    }
-
-    var execList = document.getElementById('exec-list');
-    execList.removeItem(0);
-    hasEmptyItem = false;
+function hideEmptyLabel() {
+    emptyLabel.classList.add('cordova-hidden');
+    execList.classList.remove('cordova-hidden');
 }
 

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -293,6 +293,10 @@ body /deep/ .cordova-content {
     transition: height 0.2s;
 }
 
+body /deep/ .cordova-hidden {
+    display: none;
+}
+
 .cordova-main {
     padding-bottom: 40px;
 }


### PR DESCRIPTION
Fixes #73

Edit: I changed the "No values saved" text from being a list item to being a label that we show or hide when appropriate.


===
**(The following is no longer relevant)**
A better fix would have been to change "No values saved" from a list item to a label that we just hide / show when appropriate, but unfortunately, without the use of the `hidden` attribute or the `classList` property, both of which are HTML 5, it was becoming too complex for something of such low importance.

Instead, this fix just re-adds the "No values saved" item if it is deleted, and prevents trying to remove "No values saved" from the list of saved sim results if that's the item that was deleted.