### PR TITLE
Fix #90.

### DIFF
--- a/src/modules/sim-host/sim-status.js
+++ b/src/modules/sim-host/sim-status.js
@@ -1,0 +1,31 @@
+// Copyright 2016 Intel Corporation. All rights reserved.
+
+var isAppHostReady = false,
+    appHostReadyHandlers = [];
+
+function whenAppHostReady(handler) {
+    var idx;
+    if (typeof handler !== 'function') {
+        return;
+    }
+    idx = appHostReadyHandlers.push({'handler': handler, 'fired': false});
+    if (isAppHostReady) {
+        handler();
+        appHostReadyHandlers[idx-1].fired = true;
+    }
+}
+
+function fireAppHostReady() {
+    isAppHostReady = true;
+    appHostReadyHandlers.forEach(function (element) {
+        if (!element.fired) {
+            element.handler();
+            element.fired = true;
+        }
+    });
+}
+
+/* Internal use function */
+module.exports._fireAppHostReady    = fireAppHostReady;
+/* Public API */
+module.exports.whenAppHostReady     = whenAppHostReady;

--- a/src/plugins/cordova-plugin-device/sim-host.js
+++ b/src/plugins/cordova-plugin-device/sim-host.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-var telemetry = require('telemetry-helper');
+var telemetry = require('telemetry-helper'),
+    simStatus = require('sim-status');
 
 var baseProps = {
     plugin: 'cordova-plugin-device',
@@ -446,10 +447,14 @@ module.exports = function (messages) {
 
     var cordovaVersionLabel = document.getElementById('device-cordova-version');
 
-    messages.call('cordova-version').then(function (version) {
-        cordovaVersionLabel.value = version;
-    }).fail(function () {
-        cordovaVersionLabel.value = 'unknown';
+    cordovaVersionLabel.value = 'Querying...';
+
+    simStatus.whenAppHostReady(function () {
+        messages.call('cordova-version').then(function (version) {
+            cordovaVersionLabel.value = version;
+        }).fail(function () {
+            cordovaVersionLabel.value = 'unknown';
+        });
     });
 
     return {

--- a/src/sim-host/protocol/socket.js
+++ b/src/sim-host/protocol/socket.js
@@ -2,7 +2,8 @@
 
 /*global io: false */
 
-var telemetry = require('telemetry-helper');
+var telemetry = require('telemetry-helper'),
+    simStatus = require('sim-status');
 
 var registerOnInitialize = false;
 var socket;
@@ -49,6 +50,7 @@ module.exports.initialize = function (pluginHandlers, services) {
     socket.on('app-plugin-list', function () {
         // TODO: process the list of plugins (issue #87)
         socket.emit('start');
+        simStatus._fireAppHostReady();
     });
 
     socket.once('init', function () {


### PR DESCRIPTION
Provide an API for the plugins to synchronize calls to the APP_HOST.

We had a few options to address issue #90. One of them was to simply delay premature messages to APP_HOST until it's ready on the server and the other embed plugin initialization into the lifecycle of the entire simulation.

This is an alternative approach which provides an API to the plugins to sync on for the messages which should be sent to the APP_HOST early in the initialization. I do think that unsolicited (by APP_HOST) messages and calls from SIM_HOST to APP_HOST should be a rare exception, but if they absolutely have to be sent, there's an API which allows them to do that in a coordinated manner. It does not impose any change on the plugins which do not need, just the ones that do need to use it.

Even the use case we have right now (`cordova-platform-device` plugin), should probably not be the case. Instead, `cordova.version` (and `cordova` in general) information should be returned to SIM_HOST with `app-plugin-list` message during the bootstrap.

Please let me know what you think.

@dlebu, @guillaumejenkins, @albertinad 