### PR TITLE
Create Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+    - "0.12"
+before_script:
+    - npm install -g gulp
+script:
+    gulp


### PR DESCRIPTION
Adds travis configuration to the repository. This runs the default task (which is linting right now).

A repository owner (admin) should login to https://travis-ci.org with a github accound and enable and configure travis for the repository. Detailed instructions:

1. Click `+` next to my repository.
2. Nagivate to `Microsoft` organization and then locate `cordova-simulate repository`.
3. Enable it (slider to `On`).
4. Click the gear next to `cordova-simulate` to configure details.
5. Turn ON `Build only if .travis.yml is present`.
6. Turn OFF `Build pushes`.
7. Turn OFF `Limit concurrent jobs`.
8. Turn ON `Build pull requests`.

Upon successful configuration, this pull request will have associated CI status.