### PR TITLE
Several compass simulation fixes

### DIFF
--- a/src/plugins/cordova-plugin-device-orientation/compass.js
+++ b/src/plugins/cordova-plugin-device-orientation/compass.js
@@ -7,6 +7,12 @@ var constants = {
 };
 
 var compass = {
+
+    Limits: {
+        MIN: 0,
+        MAX: 360
+    },
+
     heading: null,
 
     initialize: function () {

--- a/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
@@ -34,7 +34,7 @@
         <cordova-panel-row>
             <label for="compass-heading-value">Heading (deg)</label>
             <label data-compass-heading="text">N</label>
-            <input type="number" id="compass-heading-value" class="cordova-state-default" min="0" max="359.99">
+            <input type="number" id="compass-heading-value" class="cordova-state-default" min="0" max="359.99" step="0.5">
         </cordova-panel-row>
     </cordova-group>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-device-orientation/sim-host.js
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host.js
@@ -30,7 +30,16 @@ module.exports = function (messages) {
             },
             sendUITelemetry: sendUITelemetry
         });
+
+        var updateHeadingValue = function () {
+            var heading = compassWidget.heading();
+            compass.updateHeading(heading.value);
+            inputHeading.value = heading.value;
+            headingText.textContent = heading.direction;
+        };
+
         compassWidget.initialize(compass.heading);
+        updateHeadingValue();
 
         inputHeading.addEventListener('change', function () {
             compassWidget.updateHeading(this.value);
@@ -40,11 +49,7 @@ module.exports = function (messages) {
 
         messages.on('device-orientation-updated', function (event, value) {
             compassWidget.setHeading(value);
-
-            var heading = compassWidget.heading();
-            compass.updateHeading(heading.value);
-            inputHeading.value = heading.value;
-            headingText.textContent = heading.direction;
+            updateHeadingValue();
         }, true); // global event
     }
 

--- a/src/plugins/cordova-plugin-device-orientation/sim-host.js
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host.js
@@ -47,6 +47,12 @@ module.exports = function (messages) {
             sendUITelemetry('compass-heading-value');
         });
 
+        inputHeading.addEventListener('input', function () {
+            if (this.value < compass.Limits.MIN || this.value >= compass.Limits.MAX) {
+                this.value = compass.heading;
+            }
+        });
+
         messages.on('device-orientation-updated', function (event, value) {
             compassWidget.setHeading(value);
             updateHeadingValue();


### PR DESCRIPTION
Fix for #86 and #71. The proposed fix for the latest one is a combination of checking the maximum and minimum values that the compass heading can take, according the plugin spec, and also changing the input number step value to match the geolocation step: 0.5.