### PR TITLE
Windows API: Adding stub for Windows.UI.Notification

### DIFF
--- a/src/platforms/windows/app-host-clobbers.js
+++ b/src/platforms/windows/app-host-clobbers.js
@@ -8,7 +8,7 @@
 module.exports = {
     WinJS: {
         Application: {
-            addEventListener: function () { }
+            addEventListener: function () {}
         },
         Utilities: {
             // While simulating Windows platform, we don't currently provide
@@ -69,17 +69,17 @@ module.exports = {
                 }
             },
             CreationCollisionOption: {
-                generateUniqueName: function () { }
+                generateUniqueName: function () {}
             },
             FileIO: {},
             Pickers: {
                 PickerLocationId: {}
             },
             StorageFolder: {
-                getFolderFromPathAsync: function () { }
+                getFolderFromPathAsync: function () {}
             },
             StorageFile: {
-                getFileFromPathAsync: function () { }
+                getFileFromPathAsync: function () {}
             }
         },
         Media: {
@@ -99,6 +99,17 @@ module.exports = {
             }
         },
         UI: {
+            Notifications: {
+                ToastNotificationManager: {
+                    createToastNotifier: function () {
+                        return {
+                            getScheduledToastNotifications: function () {
+                                return {};
+                            }
+                        };
+                    }
+                }
+            },
             WebUI: {
                 WebUIApplication: {}
             }


### PR DESCRIPTION
This PR is to add a missing stub for the windows platform API: Windows.UI.Notification.
I was trying some plugins different to the core plugins, and I found that this API is missing. I guess that there are more namespaces and functions that we are missing, we should have an strategy for that. Should we mock as much as we can? Or should we provide an easy way of configuring a default behaviour for this missing API?, for the developers that are using cordova-simulate, not providing more simulation for other plugins.

Thanks!