### PR TITLE
Validate input number to be always a number

### DIFF
--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -283,6 +283,10 @@ self = module.exports = {
     },
 
     isNumber: function (value) {
+        if (typeof value === 'number') {
+            return true;
+        }
+
         return !!value.match(/-?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?/);
     }
 };

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -283,11 +283,9 @@ self = module.exports = {
     },
 
     isNumber: function (value) {
-        if (typeof value === 'number') {
-            return true;
-        }
+        var type = typeof value;
 
-        return !!value.match(/-?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?/);
+        return (type === 'number' || type === 'string') && !isNaN(value - parseFloat(value));
     }
 };
 

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -280,6 +280,10 @@ self = module.exports = {
             !url.href.match(/^https?:\/\/|^file:\/\//);
 
         return !!sameOrigin;
+    },
+
+    isNumber: function (value) {
+        return !!value.match(/-?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?/);
     }
 };
 

--- a/src/plugins/cordova-plugin-device-orientation/sim-host.js
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host.js
@@ -2,7 +2,8 @@
 
 module.exports = function (messages) {
 
-    var telemetry = require('telemetry-helper'),
+    var utils = require('utils'),
+        telemetry = require('telemetry-helper'),
         CompassWidget = require('./compass-widget'),
         compass = require('./compass');
 
@@ -48,8 +49,7 @@ module.exports = function (messages) {
         });
 
         inputHeading.addEventListener('input', function () {
-            if (!this.value.match(/-?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?/) ||
-                (this.value < compass.Limits.MIN || this.value >= compass.Limits.MAX)) {
+            if (!utils.isNumber(this.value) || (this.value < compass.Limits.MIN || this.value >= compass.Limits.MAX)) {
                 this.value = compass.heading;
             }
         });

--- a/src/plugins/cordova-plugin-device-orientation/sim-host.js
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host.js
@@ -48,7 +48,8 @@ module.exports = function (messages) {
         });
 
         inputHeading.addEventListener('input', function () {
-            if (this.value < compass.Limits.MIN || this.value >= compass.Limits.MAX) {
+            if (!this.value.match(/-?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?/) ||
+                (this.value < compass.Limits.MIN || this.value >= compass.Limits.MAX)) {
                 this.value = compass.heading;
             }
         });

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -167,6 +167,7 @@ function initialize(changePanelVisibilityCallback) {
     registerCustomElement('cordova-number-entry', {
         value: {
             set: function (value) {
+                this._internalValue = value;
                 setValueSafely(this.shadowRoot.querySelector('input'), 'value', value);
             },
 
@@ -201,6 +202,20 @@ function initialize(changePanelVisibilityCallback) {
         if (step !== null) {
             input.setAttribute('step', step);
         }
+
+        // verify and force the input value to be a valid number
+        input.addEventListener('input', function (event) {
+            var value = event.target.value;
+
+            if (value.match(/-?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?/)) {
+                this._internalValue = value;
+            } else {
+                // the new value is not a number, set the value to the
+                // latest number value
+                input.value = this._internalValue;
+                return false;
+            }
+        }.bind(this));
     }, 'input');
 
     registerCustomElement('cordova-labeled-value', {

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-var dialog = require('dialog');
+var dialog = require('dialog'),
+    utils = require('utils');
 
 function initialize(changePanelVisibilityCallback) {
     registerCustomElement('cordova-panel', {
@@ -207,7 +208,7 @@ function initialize(changePanelVisibilityCallback) {
         input.addEventListener('input', function (event) {
             var value = event.target.value;
 
-            if (value.match(/-?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?/)) {
+            if (utils.isNumber(value)) {
                 this._internalValue = value;
             } else {
                 // the new value is not a number, set the value to the

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -168,7 +168,12 @@ function initialize(changePanelVisibilityCallback) {
     registerCustomElement('cordova-number-entry', {
         value: {
             set: function (value) {
-                this._internalValue = value;
+                if (utils.isNumber(value)) {
+                    this._internalValue = value;
+                } else {
+                    value = this._internalValue;
+                }
+
                 setValueSafely(this.shadowRoot.querySelector('input'), 'value', value);
             },
 
@@ -185,24 +190,29 @@ function initialize(changePanelVisibilityCallback) {
         this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');
         this.classList.add('cordova-panel-row');
         this.classList.add('cordova-group');
+        this._internalValue = 0;
 
         var input = this.shadowRoot.querySelector('input');
 
         var maxValue = this.getAttribute('max'),
             minValue = this.getAttribute('min'),
+            value = this.getAttribute('value'),
             step = this.getAttribute('step');
 
-        if (maxValue !== null) {
-            input.setAttribute('max', maxValue);
+        // initialize _internalValue with one of the availale values,
+        // otherwise it remains 0
+        if (value !== null && utils.isNumber(value)) {
+            this._internalValue = value;
+        } else if (minValue !== null && utils.isNumber(minValue)) {
+            this._internalValue = minValue;
+        } else if (maxValue !== null && utils.isNumber(maxValue) && this._internalValue > parseFloat(maxValue)) {
+            this._internalValue =  maxValue;
         }
 
-        if (minValue !== null) {
-            input.setAttribute('min', minValue);
-        }
-
-        if (step !== null) {
-            input.setAttribute('step', step);
-        }
+        if (maxValue !== null) input.setAttribute('max', maxValue);
+        if (minValue !== null) input.setAttribute('min', minValue);
+        if (step !== null) input.setAttribute('step', step);
+        if (value !== null) input.setAttribute('value', value);
 
         // verify and force the input value to be a valid number
         input.addEventListener('input', function (event) {


### PR DESCRIPTION
According to the browser and version, sometimes a non-number is allowed in the input number field. This PR is for adding a validation to force any value of the `cordova-number-entry` to be a number. When a non-number value is added, or `""` the previous value is used to update the input value.
The `orientation` plugin doesn't use this component, so instead of that, I've added the common validation with the other validations that it has.
