### PR TITLE
Fixing promise callback scope in SimulationServer.

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -227,7 +227,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
                         .pipe(replaceStream('default-src \'self\'', 'default-src \'self\' ws: blob:'));
                 }
             }).pipe(response);
-        })
+        }.bind(this))
         .done();
 };
 


### PR DESCRIPTION
This fixes a missing call to `bind` in a promise callback.