### PR TITLE
Fix XHR proxy with non-standard ports

### DIFF
--- a/src/server/xhr-proxy.js
+++ b/src/server/xhr-proxy.js
@@ -13,7 +13,7 @@ module.exports.attach = function (app) {
         delete request.headers['accept-encoding'];
 
         var options = {
-            host: requestURL.host,
+            hostname: requestURL.hostname,
             path: requestURL.path,
             port: requestURL.port,
             method: request.method,


### PR DESCRIPTION
If a non-standard port is used, then the port will double-up at the moment, leading to a failure to contact `example.com:8080:8080`. Specifying `hostname` rather than `host` fixes this issue.