### PR TITLE
Updating require usages in cordova-plugin-device-motion simulation.

### DIFF
--- a/src/plugins/cordova-plugin-device-motion/device-motion-model.js
+++ b/src/plugins/cordova-plugin-device-motion/device-motion-model.js
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+// report interval in milliseconds
+var ACCELEROMETER_REPORT_INTERVAL = 50;
+
+var _onChangeCallback,
+    _axis = {
+        x: 0,
+        y: 0,
+        z: 0
+    };
+
+function updateAxis(values) {
+    values = values || {};
+
+    var updatedValues = {};
+
+    if (values.x) {
+        _axis.x = parseFloat(values.x);
+        updatedValues.x = _axis.x;
+    }
+
+    if (values.y) {
+        _axis.y = parseFloat(values.y);
+        updatedValues.y = _axis.y;
+    }
+
+    if (values.z) {
+        _axis.z = parseFloat(values.z);
+        updatedValues.z = _axis.z;
+    }
+
+    // notify if any value has been updated
+    if (Object.keys(updatedValues).length > 0 && _onChangeCallback) {
+        _onChangeCallback(updatedValues);
+    }
+}
+
+function addAxisChangeCallback(callback) {
+    _onChangeCallback = (typeof callback === 'function') ? callback : null;
+}
+
+module.exports = {
+    updateAxis: updateAxis,
+    addAxisChangeCallback: addAxisChangeCallback,
+    get x() {
+        return _axis.x;
+    },
+    get y() {
+        return _axis.y;
+    },
+    get z() {
+        return _axis.z;
+    },
+    ACCELEROMETER_REPORT_INTERVAL: ACCELEROMETER_REPORT_INTERVAL
+};

--- a/src/plugins/cordova-plugin-device-motion/sim-host-handlers.js
+++ b/src/plugins/cordova-plugin-device-motion/sim-host-handlers.js
@@ -1,14 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-var deviceMotion = require('cordova-plugin-device-motion');
+var deviceMotionModel = require('./device-motion-model');
+
 var accelerometerHandle = null;
+
+function getCurrentAcceleration () {
+    return {
+        x: deviceMotionModel.x,
+        y: deviceMotionModel.y,
+        z: deviceMotionModel.z,
+        timestamp: (new Date()).getTime()
+    };
+}
 
 module.exports = {
     'Accelerometer': {
         start: function (win, lose) {
             accelerometerHandle = setInterval(function() {
                 win(getCurrentAcceleration());
-            }, deviceMotion.ACCELEROMETER_REPORT_INTERVAL);
+            }, deviceMotionModel.ACCELEROMETER_REPORT_INTERVAL);
         },
         stop: function (win, lose) {
             if (accelerometerHandle === null) {
@@ -23,12 +33,3 @@ module.exports = {
         }
     }
 };
-
-function getCurrentAcceleration () {
-    return {
-        x: parseFloat(deviceMotion.x),
-        y: parseFloat(deviceMotion.y),
-        z: parseFloat(deviceMotion.z),
-        timestamp: (new Date()).getTime()
-    };
-}


### PR DESCRIPTION
The simulator server crashes when trying to generate the browserify context for a project that contains an old version of `cordova-plugin-device-motion` plugin, like version `0.2.11`. That old version has the old name of the plugin: `org.apache.cordova.device-motion`. I tried with different old plugins, and there was any problem, but with this one in particular, the server crashes with the following error:
```
/<folder>/cordova-simulate/node_modules/q/q.js:155
                throw e;
                      ^
Error: Cannot find module 'cordova-plugin-device-motion' from '/<folder>/cordova-simulate/src/plugins/cordova-plugin-device-motion'
    at /<folder>/cordova-simulate/node_modules/browserify/node_modules/resolve/lib/async.js:46:17
    at process (/<folder>/cordova-simulate/node_modules/browserify/node_modules/resolve/lib/async.js:173:43)
    at ondir (/<folder>/cordova-simulate/node_modules/browserify/node_modules/resolve/lib/async.js:188:17)
    at load (/<folder>/cordova-simulate/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
    at onex (/<folder>/cordova-simulate/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
    at /<folder>/cordova-simulate/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
    at Object.oncomplete (fs.js:108:15)

```

The folders of for the plugin simulation exists, but in this particular case the module with the name of `cordova-plugin-device-motion`, that matches the plugin simulation folder and the plugin ID in the new style, doesn't exists in the browserify context. This error happens because the simulation plugin it is assuming that in browserify context, the name of the main entry point to the simulation module matches the folder and the ID in the new style, and try to [require it](https://github.com/Microsoft/cordova-simulate/blob/master/src/plugins/cordova-plugin-device-motion/sim-host-handlers.js#L3). But that seems to not always be true when the project has an old plugin. I guess that the name in browserify for this case is `org.apache.cordova.device-motion`.
As a proposal for fixing this issue, the simulation should not assume names of modules, so I changed the way the accelerometer axis values are used by `sim-host-handlers.js`: a new module that encapsulates the data model is added and used by `sim-host-handlers.js` and `sim-host.js`.

Besides that we don't official support simulation for different versions of plugins (built-in), I think that the server should not crash on this cases.

Thanks! 