### PR TITLE
Move prepare retry logic from LiveReload to execCordovaPrepare.

### DIFF
--- a/src/server/live-reload/live-reload.js
+++ b/src/server/live-reload/live-reload.js
@@ -49,7 +49,7 @@ LiveReload.prototype._onFileChanged = function (fileRelativePath, parentDir) {
     if (this._forcePrepare) {
         // Sometimes, especially on Windows, prepare will fail because the modified file is locked for a short duration
         // after modification, so we try to prepare twice.
-        propagateChangePromise = retryAsync(this._project.prepare.bind(this._project), 2)
+        propagateChangePromise = this._project.prepare()
             .then(function () {
                 return false;
             });
@@ -81,22 +81,6 @@ LiveReload.prototype._onFileChanged = function (fileRelativePath, parentDir) {
 
 function copyFile(src, dest) {
     return Q.nfcall(ncp, src, dest);
-}
-
-function retryAsync(promiseFunc, maxTries, delay, iteration) {
-    delay = delay || 100;
-    iteration = iteration || 1;
-
-    return promiseFunc().catch(function (err) {
-        if (iteration < maxTries) {
-            return Q.delay(delay)
-                .then(function () {
-                    return retryAsync(promiseFunc, maxTries, delay, iteration + 1);
-                });
-        }
-
-        return Q.reject(err);
-    });
 }
 
 module.exports = LiveReload;

--- a/src/server/utils/prepare.js
+++ b/src/server/utils/prepare.js
@@ -2,7 +2,8 @@
 
 var exec = require('child_process').exec,
     Q = require('q'),
-    log = require('./log');
+    log = require('./log'),
+    utils = require('./jsUtils');
 
 /**
  * @param {string} projectRoot
@@ -10,21 +11,27 @@ var exec = require('child_process').exec,
  * @return {Promise}
  */
 function execCordovaPrepare(projectRoot, platform) {
-    var deferred = Q.defer();
+    return utils.retryAsync(getExecCordovaPrepareImpl(projectRoot, platform));
+}
 
-    log.log('Preparing platform \'' + platform + '\'.');
+function getExecCordovaPrepareImpl(projectRoot, platform) {
+    return function () {
+        var deferred = Q.defer();
 
-    exec('cordova prepare ' + platform, {
-        cwd: projectRoot
-    }, function (err, stdout, stderr) {
-        if (err) {
-            deferred.reject(err || stderr);
-        }
+        log.log('Preparing platform \'' + platform + '\'.');
 
-        deferred.resolve();
-    });
+        exec('cordova prepare ' + platform, {
+            cwd: projectRoot
+        }, function (err) {
+            if (err) {
+                deferred.reject(err);
+            } else {
+                deferred.resolve();
+            }
+        });
 
-    return deferred.promise;
+        return deferred.promise;
+    };
 }
 
 module.exports.execCordovaPrepare = execCordovaPrepare;


### PR DESCRIPTION
Currently `LiveReload` will try a second time to prepare if the first time fails (usually because of errors trying to create www folder too quickly on Windows). This moves that logic into `execCordovaPrepare()` itself, so we gain the same benefit in other scenarios.

(I'm seeing this failure regularly on the first launch of simulations from VS Code)