### PR TITLE
Move prepare retry logic from LiveReload to execCordovaPrepare.

### DIFF
--- a/src/server/jsUtils.js
+++ b/src/server/jsUtils.js
@@ -1,3 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+var Q = require('q');
+
+var DEFAULT_ASYNC_RETRY_ATTEMPTS = 2;
+
 /**
  * Returns true if the specified objects are considered similar. Here, similarity is defined as having the same keys,
  * mapping to equal values (for value properties) or similar values (for arrays or nested objects). Does not correctly
@@ -101,5 +107,30 @@ function compareArrays(a1, a2, compareOrder) {
     return isSimilar;
 }
 
+/**
+ * Calls a function that returns a promise, then retries a certain number a times, after a timeout, if an error occurs.
+ * @param {function} promiseFunc - The function to call.
+ * @param {number} [maxTries=2] - The maximum number of tries before accepting failure. Defaults to 2.
+ * @param {number} [delay=100] - The delay between retries in ms. Default to 100.
+ * @returns {Promise}
+ */
+function retryAsync(promiseFunc, maxTries, delay, iteration) {
+    maxTries = maxTries || DEFAULT_ASYNC_RETRY_ATTEMPTS;
+    delay = delay || 100;
+    iteration = iteration || 1;
+
+    return promiseFunc().catch(function (err) {
+        if (iteration < maxTries) {
+            return Q.delay(delay)
+                .then(function () {
+                    return retryAsync(promiseFunc, maxTries, delay, iteration + 1);
+                });
+        }
+
+        return Q.reject(err);
+    });
+}
+
 module.exports.compareObjects = compareObjects;
 module.exports.compareArrays = compareArrays;
+module.exports.retryAsync = retryAsync;

--- a/src/server/live-reload/live-reload-server.js
+++ b/src/server/live-reload/live-reload-server.js
@@ -21,7 +21,7 @@ function onFileChanged(fileRelativePath, parentDir) {
     if (config.forcePrepare) {
         // Sometimes, especially on Windows, prepare will fail because the modified file is locked for a short duration
         // after modification, so we try to prepare twice.
-        propagateChangePromise = retryAsync(prepare.prepare, 2).then(function () {
+        propagateChangePromise = prepare.prepare().then(function () {
             return false;
         });
     } else {
@@ -49,21 +49,6 @@ function onFileChanged(fileRelativePath, parentDir) {
 
 function copyFile(src, dest) {
     return Q.nfcall(ncp, src, dest);
-}
-
-function retryAsync(promiseFunc, maxTries, delay, iteration) {
-    delay = delay || 100;
-    iteration = iteration || 1;
-
-    return promiseFunc().catch(function (err) {
-        if (iteration < maxTries) {
-            return Q.delay(delay).then(function () {
-                return retryAsync(promiseFunc, maxTries, delay, iteration + 1);
-            });
-        }
-
-        return Q.reject(err);
-    });
 }
 
 module.exports.init = function (sock) {

--- a/src/server/prepare.js
+++ b/src/server/prepare.js
@@ -61,6 +61,10 @@ function prepare() {
 }
 
 function execCordovaPrepare() {
+    return jsUtils.retryAsync(execCordovaPrepareImpl);
+}
+
+function execCordovaPrepareImpl() {
     var projectRoot;
     var platform;
     var deferred = Q.defer();
@@ -76,12 +80,12 @@ function execCordovaPrepare() {
 
     exec('cordova prepare ' + platform, {
         cwd: projectRoot
-    }, function (err, stdout, stderr) {
+    }, function (err) {
         if (err) {
-            deferred.reject(err || stderr);
+            deferred.reject(err);
+        } else {
+            deferred.resolve();
         }
-
-        deferred.resolve();
     });
 
     return deferred.promise;


### PR DESCRIPTION
This is a version of the same change as before, but for the 0.2.x branch (underlying code has changed enough that I can't just cherry pick this one).