### PR TITLE
Improving XHR proxy

### DIFF
--- a/src/modules/xhr-proxy.js
+++ b/src/modules/xhr-proxy.js
@@ -24,6 +24,9 @@ var init = function () {
 
         return xhr;
     };
+
+    // Ensure that we retain all static properties, such as DONE
+    window.XMLHttpRequest.__proto__ = _XMLHttpRequest;
 };
 
 module.exports = {

--- a/src/server/xhr-proxy.js
+++ b/src/server/xhr-proxy.js
@@ -24,10 +24,17 @@ module.exports.attach = function (app) {
             proxyReponse.pipe(response);
         };
         
+        var proxyRequest;
+
         if (requestURL.protocol === 'https:') {
-            https.request(options, proxyCallback).end();
+            proxyRequest = https.request(options, proxyCallback);
         } else {
-            http.request(options, proxyCallback).end();
+            proxyRequest = http.request(options, proxyCallback);
         }
+
+        proxyRequest.on('error', function (err) {
+            response.status(502).send(err.toString()).end();
+        });
+        proxyRequest.end();
     });
 };


### PR DESCRIPTION
With the XHR proxy enabled, previously we would lose the static properties of XMLHttpRequest, such as DONE and LOADING. We now make sure to include these properties.

Additionally, since the connection from the app to the proxy always succeeds we do not correctly handle network level failures. Now if there is an error in the communication itself (as distinct from recieving a 404 for example) we report back a 502 Bad Gateway error, and include the error message to inform the app developer about the issue.

fixes #111
fixes #112 