### PR TITLE
Fixing race condition in subscribing to socket events

### DIFF
--- a/src/server/socket.js
+++ b/src/server/socket.js
@@ -309,6 +309,7 @@ SocketServer.prototype._subscribeTo = function (host, msg, handler, once) {
     var socket = this._hostSockets[host],
         method = once ? 'once' : 'on';
     if (socket) {
+        socket.removeListener(msg, handler);
         socket[method](msg, handler);
     } else {
         log.log('Subscribing to a disconnected ' + host + ' wanting \'' + msg + '\'');


### PR DESCRIPTION
When using VSCode I found that a single `cordova.exec` call from APP_HOST would sometimes trigger two responses from SIM_HOST. This turns out to be because `onSimHostReady` could be called twice without `resetAppHostState` called in between. As a fix, this commit ensures that each handler is only registered once.