### PR TITLE
Updating sim hosts file injection while streaming app host.

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -223,7 +223,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
             send(request, filePath, {
                 transform: function (stream) {
                     return stream
-                        .pipe(replaceStream(/<\s*head\s*>/, '<head>' + scriptTags))
+                        .pipe(replaceStream(/(<\s*head.*>)/, '$1' + scriptTags))
                         .pipe(replaceStream('default-src \'self\'', 'default-src \'self\' ws: blob:'));
                 }
             }).pipe(response);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -223,7 +223,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
             send(request, filePath, {
                 transform: function (stream) {
                     return stream
-                        .pipe(replaceStream(/(<\s*head.*>)/, '$1' + scriptTags))
+                        .pipe(replaceStream(/(<\s*head[^>]*>)/, '$1' + scriptTags))
                         .pipe(replaceStream('default-src \'self\'', 'default-src \'self\' ws: blob:'));
                 }
             }).pipe(response);


### PR DESCRIPTION
Update regex to support matching `<head>` with content like `data-*` attributes. 
Also updating replace mechanism with [captures](https://github.com/eugeneware/replacestream/#search-and-replace-with-regular-expressions) for inserting the new head: do not replace it
with a new one, take the current head and add the script files.
This fixes #128.

Thanks!