### PR TITLE
Changing to semantic CSP injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chalk": "^1.1.1",
     "cordova-registry-mapper": "^1.1.12",
     "cordova-serve": "^1.0.0",
+    "csp-parse": "^0.0.2",
     "glob": "^7.0.5",
     "minimist": "^1.2.0",
     "ncp": "^2.0.0",

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -15,6 +15,13 @@ var fs = require('fs'),
     pluginSimulationFiles = require('./plugin-files');
 
 /**
+ * Maximum length of <meta> tag we search for when modifying CSP properties
+ * Needed for when a tag crosses multiple chunk boundaries.
+ * @const
+ */
+var MAX_CSP_TAG_LENGTH = 1024;
+
+/**
  * The simulation server that encapsulates the HTTP server instance and
  * Web Socket server. It enables to start and stop the server to listening
  * for new connections.
@@ -225,7 +232,6 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
             var metaTagRegex = /<\s*meta[^>]*>/g;
             var cspRegex = /http-equiv\s*=\s*(['"])Content-Security-Policy\1/;
             var cspContent = /(content\s*=\s*")([^"]*)"/;
-            var maxCspTagLength = 1024;
             send(request, filePath, {
                 transform: function (stream) {
                     return stream
@@ -248,7 +254,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
                                 policy.add('img-src', 'blob:');
                                 return preamble + policy.toString() + '"';
                             });
-                        }, {maxMatchLen: maxCspTagLength}));
+                        }, {maxMatchLen: MAX_CSP_TAG_LENGTH}));
                 }
             }).pipe(response);
         }.bind(this))

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -240,7 +240,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
                                 if (!policy.get('connect-src')) {
                                     policy.add('connect-src', defaultCsp);
                                 }
-                                policy.add('connect-src', "'self' ws:");
+                                policy.add('connect-src', '\'self\' ws:');
                                 if (!policy.get('img-src')) {
                                     policy.add('img-src', defaultCsp);
                                 }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -247,7 +247,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
                                 policy.add('img-src', 'blob:');
                                 return preamble + policy.toString() + '"';
                             });
-                        }));
+                        }, {maxMatchLen: 1024}));
                 }
             }).pipe(response);
         }.bind(this))

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -222,9 +222,10 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
             // Note we add "connect-src 'self' ws:" and "img-src 'blob:' (in Content Security Policy) so that
             // websocket connections are allowed and the camera plugin works (this relies on a custom version
             // of send that supports a 'transform' option).
-            var metaTagRegex = /<\s*meta[^>]*>/;
+            var metaTagRegex = /<\s*meta[^>]*>/g;
             var cspRegex = /http-equiv\s*=\s*(['"])Content-Security-Policy\1/;
-            var cspContent = /(content\s*=\s*")([^"]*)"/
+            var cspContent = /(content\s*=\s*")([^"]*)"/;
+            var maxCspTagLength = 1024;
             send(request, filePath, {
                 transform: function (stream) {
                     return stream
@@ -247,7 +248,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
                                 policy.add('img-src', 'blob:');
                                 return preamble + policy.toString() + '"';
                             });
-                        }, {maxMatchLen: 1024}));
+                        }, {maxMatchLen: maxCspTagLength}));
                 }
             }).pipe(response);
         }.bind(this))

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -222,7 +222,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
             // Note we add "connect-src 'self' ws:" and "img-src 'blob:' (in Content Security Policy) so that
             // websocket connections are allowed and the camera plugin works (this relies on a custom version
             // of send that supports a 'transform' option).
-            var metaTagRegex = /<meta[^>]*>/;
+            var metaTagRegex = /<\s*meta[^>]*>/;
             var cspRegex = /http-equiv\s*=\s*(['"])Content-Security-Policy\1/;
             var cspContent = /(content\s*=\s*")([^"]*)"/
             send(request, filePath, {


### PR DESCRIPTION
Instead of simply injecting some additional entries into the default-src of the csp, we now properly parse it and add the specific constraints that we care about. In particular, we make sure to preserve any previous constraints, but we allow websocket connections to 'self' and blob urls for images.

Fixes #130 