### PR TITLE
Rename browserify/app-host global require.

### DIFF
--- a/src/server/sim-files.js
+++ b/src/server/sim-files.js
@@ -142,7 +142,8 @@ SimulationFiles.prototype._createHostJsFile = function (simulationFilePath, host
     var b = browserify({
         paths: getBrowserifySearchPaths(hostType),
         debug: true,
-        externalRequireName: '_cordovaSimulateRequire'
+        exports: false, // needed to prevent browserify to override hasExports option by set it to true
+        hasExports: false
     });
 
     b.transform(function (file) {

--- a/src/server/sim-files.js
+++ b/src/server/sim-files.js
@@ -139,7 +139,12 @@ SimulationFiles.prototype._createHostJsFile = function (simulationFilePath, host
 
     var scriptDefs = createScriptDefs(hostType, scriptTypes);
 
-    var b = browserify({ paths: getBrowserifySearchPaths(hostType), debug: true });
+    var b = browserify({
+        paths: getBrowserifySearchPaths(hostType),
+        debug: true,
+        externalRequireName: '_cordovaSimulateRequire'
+    });
+
     b.transform(function (file) {
         if (file === filePath) {
             var data = '';


### PR DESCRIPTION
Rename the `require` global variable injected by app-host (browserify) to another name, avoiding conflicts with other module loaders like `requirejs`.
Intel XDK user [reported issue](https://software.intel.com/en-us/forums/intel-xdk/topic/673464).