### PR TITLE
Support simulation when there's no plugins added to the project.

### DIFF
--- a/src/app-host/app-host.js
+++ b/src/app-host/app-host.js
@@ -109,7 +109,7 @@ function setCordovaAndInitialize(originalCordova) {
     });
 
     socket.on('init-xhr-proxy', function () {
-        require('xhr-proxy').init(); 
+        require('xhr-proxy').init();
     });
 
     socket.on('init-touch-events', function () {
@@ -137,7 +137,14 @@ function setCordovaAndInitialize(originalCordova) {
 
         if (cordova.platformId !== 'browser') {
             channel.onPluginsReady.subscribe(function () {
-                var pluginList = cordova.require('cordova/plugin_list').metadata;
+                var pluginList;
+                try {
+                    pluginList = cordova.require('cordova/plugin_list').metadata;
+                } catch (ex) {
+                    // when the app doesn't contain any plugin, the module "cordova/plugin_list"
+                    // is not loaded and cordova.require throws an exception
+                    pluginList = {};
+                }
                 socket.emit('app-plugin-list', pluginList);
             });
         } else {

--- a/src/server/project.js
+++ b/src/server/project.js
@@ -70,12 +70,6 @@ Project.DEFAULT_PLUGINS = [
     'events'
 ];
 
-/**
- * @const
- * @private
- */
-Project._PLUGINS_LIST_BAD_STATE = ['__unknown__'];
-
 Project.prototype.initPlugins = function () {
     this._resetPluginsData();
 
@@ -328,18 +322,18 @@ Project.prototype._getProjectState = function() {
         })
         .fail(function () {
             // an error ocurred trying to read the file for the current platform,
-            // set the pluginsList to indicate a "bad state".
-            newState.pluginList = Project._PLUGINS_LIST_BAD_STATE;
+            // return an empty json file content
+            return '{}';
         })
         .then(function (fileContent) {
-            var installedPlugins = {};
+            var installedPlugins;
 
             try {
                 installedPlugins = Object.keys(JSON.parse(fileContent.toString())['installed_plugins'] || {});
             } catch (err) {
                 // For some reason, it was not possible to determine which plugins are installed for the current platform, so
                 // use a dummy value to indicate a "bad state".
-                installedPlugins = Project._PLUGINS_LIST_BAD_STATE;
+                installedPlugins = ['__unknown__'];
             }
 
             newState.pluginList = installedPlugins;

--- a/src/server/project.js
+++ b/src/server/project.js
@@ -61,11 +61,20 @@ Object.defineProperties(Project.prototype, {
     }
 });
 
+/**
+ * @const
+ */
 Project.DEFAULT_PLUGINS = [
     'cordova-plugin-geolocation',
     'exec',
     'events'
 ];
+
+/**
+ * @const
+ * @private
+ */
+Project._PLUGINS_LIST_BAD_STATE = ['__unknown__'];
 
 Project.prototype.initPlugins = function () {
     this._resetPluginsData();
@@ -317,6 +326,11 @@ Project.prototype._getProjectState = function() {
             var pluginsJsonPath = path.join(projectRoot, 'plugins', platform + '.json');
             return Q.nfcall(fs.readFile, pluginsJsonPath);
         })
+        .fail(function () {
+            // an error ocurred trying to read the file for the current platform,
+            // set the pluginsList to indicate a "bad state".
+            newState.pluginList = Project._PLUGINS_LIST_BAD_STATE;
+        })
         .then(function (fileContent) {
             var installedPlugins = {};
 
@@ -325,7 +339,7 @@ Project.prototype._getProjectState = function() {
             } catch (err) {
                 // For some reason, it was not possible to determine which plugins are installed for the current platform, so
                 // use a dummy value to indicate a "bad state".
-                installedPlugins = ['__unknown__'];
+                installedPlugins = Project._PLUGINS_LIST_BAD_STATE;
             }
 
             newState.pluginList = installedPlugins;


### PR DESCRIPTION
There are some cases during the development of a cordova app in which developers  doesn't add any plugins to the project. They even remove the whitelist plugin, that is included when adding a platform to the project. 
When trying to simulate an app without any plugin, the server crashes due to an ENOENT exception, 
```
SIM: Server started:
- App running at: http://localhost:8000/index.html
- Sim host running at: http://localhost:8000/simulator/index.html
/Users/<user>/cordova-simulate/node_modules/q/q.js:155
                throw e;
                      ^
Error: ENOENT, open '/Users/<user>/apps/device/plugins/android.json'
    at Error (native)

```
The platform json file is not generated, it doesn't exists.
Once that is fixed, when removing all the plugins and running cordova prepare and start the simulation, device ready is never fired due to an unhandled exception in the execution of the simulation protocol.
```
cordova.js:59 Uncaught module cordova/plugin_list not found
```
This happens when doing
```
cordova.require('cordova/plugin_list')
```
to get the list of installed plugins. The `cordova/plugin_list` module is loaded and available when the `cordova_plugins.js` file is successfully created as a result of the cordova prepare operation. When no plugins are available, that file is not created, and the module is not loaded.

This PR fixes this corner cases in which a developer simulates the app that doesn't have any plugin installed.