### PR TITLE
Fix for updating battery status label in sim-host (IE)

### DIFF
--- a/src/plugins/cordova-plugin-battery-status/sim-host.js
+++ b/src/plugins/cordova-plugin-battery-status/sim-host.js
@@ -30,6 +30,7 @@ module.exports = function (message) {
         // attach event listeners
         levelRange.addEventListener('change', function () {
             battery.updateBatteryLevel(this.value);
+            updateBatteryLevelText(this.value);
         });
 
         levelRange.addEventListener('input', function () {


### PR DESCRIPTION
When testing cordova-simulate in IE 11, I found that the label that indicate the current battery level wasn't reflecting the change of the level while using the input range. This is due to the `input` event is not fired in IE, but `change` event is fired as soon as the value changes.
This PR is a quick fix, following the same approach done in other plugin's widget that uses `input range` element.
We could handle all of this in a web component, and also enable adding a label at the right or left of the input range, similar to the implementation done for `cordova-plugin-battery-status` and `cordova-plugin-geolocation`.