### PR TITLE
Rendering improvements in non-Chrome browsers.

### DIFF
--- a/src/sim-host/ui/server/server.js
+++ b/src/sim-host/ui/server/server.js
@@ -4,22 +4,35 @@ var path = require('path'),
     replaceStream = require('replacestream'),
     send = require('send-transform');
 
+var BROWSER_REPLACE_MAX_MATCH_LENGTH = 1024;
+var BROWSER_REPLACE_OPTIONS = {maxMatchLen: BROWSER_REPLACE_MAX_MATCH_LENGTH};
+
 module.exports.attach = function (app, dirs, hostRoot) {
-    app.get('/simulator/sim-host.css', function (request, response, next) {
+    app.get('/simulator/sim-host.css', function (request, response) {
         var userAgent = request.headers['user-agent'];
-        if (userAgent.indexOf('Chrome') > -1 && userAgent.indexOf('Edge/') === -1) {
-            next();
-        } else {
-            // If target browser isn't Chrome (user agent contains 'Chrome', but isn't 'Edge'), remove shadow dom stuff from
-            // the CSS file. Also remove any sections marked as Chrome specific.
-            send(request, path.resolve(hostRoot['sim-host'], 'sim-host.css'), {
-                transform: function (stream) {
-                    return stream
-                        .pipe(replaceStream('> ::content >', '>'))
-                        .pipe(replaceStream(/\^|\/shadow\/|\/shadow-deep\/|::shadow|\/deep\/|::content|>>>/g, ' '))
-                        .pipe(replaceStream(/\/\* BEGIN CHROME ONLY \*\/[\s\S]*\/\* END CHROME ONLY \*\//gm, ''));
-                }
-            }).pipe(response);
-        }
+        send(request, path.resolve(hostRoot['sim-host'], 'sim-host.css'), {
+            transform: getTransform(userAgent)
+        }).pipe(response);
     });
 };
+
+function getTransform(userAgent) {
+    if (isChrome(userAgent)) {
+        // If target browser is Chrome, remove any sections marked as not for Chrome.
+        return function (stream) {
+            return stream.pipe(replaceStream(/\/\* BEGIN !CHROME \*\/[\s\S]*\/\* END !CHROME \*\//gm, '', BROWSER_REPLACE_OPTIONS));
+        };
+    }
+
+    // If target browser is not Chrome, remove shadow dom stuff and any sections marked as for Chrome.
+    return function (stream) {
+        return stream
+            .pipe(replaceStream('> ::content >', '>'))
+            .pipe(replaceStream(/\^|\/shadow\/|\/shadow-deep\/|::shadow|\/deep\/|::content|>>>/g, ' '))
+            .pipe(replaceStream(/\/\* BEGIN CHROME \*\/[\s\S]*\/\* END CHROME \*\//gm, '', BROWSER_REPLACE_OPTIONS));
+    };
+}
+
+function isChrome(userAgent) {
+    return userAgent.indexOf('Chrome') > -1 && userAgent.indexOf('Edge/') === -1;
+}

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -33,7 +33,6 @@ a {
 
 cordova-panel {
     width: 320px;
-    padding: 5px 0;
 }
 
 cordova-dialog {
@@ -292,14 +291,10 @@ body /deep/ .cordova-hidden {
     display: none;
 }
 
-.cordova-main {
-    padding-bottom: 40px;
-}
-
 /* Hacks to work around multi-column bug in Chrome 48+. The following section
    is removed for other browsers when the file is served */
 
-/* BEGIN CHROME ONLY */
+/* BEGIN CHROME */
 body /deep/ .cordova-panel-inner {
     overflow: visible;
     padding-bottom: 1px;
@@ -308,4 +303,22 @@ body /deep/ .cordova-panel-inner {
 body /deep/ .cordova-content {
     overflow: visible;
 }
-/* END CHROME ONLY */
+
+cordova-panel {
+    padding: 5px 0;
+}
+
+.cordova-main {
+    padding-left: 5px;
+}
+/* END CHROME */
+
+/* BEGIN !CHROME */
+body .cordova-panel-inner {
+    margin-bottom: 10px;
+}
+
+.cordova-main {
+    padding: 5px;
+}
+/* END !CHROME */


### PR DESCRIPTION
Chrome renders columns differently to other browsers. The current CSS was optimized for Chrome, and didn't work well in IE (top of columns wasn't aligned, often had empty first column). This change tweaks some values to be specific for Chrome and some values only for non-Chrome browsers (the non-Chrome values also work fine in Firefox).

I'll keep working towards an approach that works consistently across browsers without needing special case stuff, but until I get there, I need this change to unblock current work.