### PR TITLE
Configure "step" attribute of all cordova-input-number used.

### DIFF
--- a/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
@@ -34,7 +34,7 @@
         <cordova-panel-row>
             <label for="compass-heading-value">Heading (deg)</label>
             <label data-compass-heading="text">N</label>
-            <input type="number" id="compass-heading-value" class="cordova-state-default" min="0" max="359.99" step="0.5">
+            <input type="number" id="compass-heading-value" class="cordova-state-default" min="0" max="359.99" step="any">
         </cordova-panel-row>
     </cordova-group>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -40,13 +40,13 @@
 
     <cordova-number-entry label="Latitude" id="geo-latitude" step="any"></cordova-number-entry>
     <cordova-number-entry label="Longitude" id="geo-longitude" step="any"></cordova-number-entry>
-    <cordova-number-entry label="Altitude (m)" id="geo-altitude" min="0" step="any"></cordova-number-entry>
+    <cordova-number-entry label="Altitude (m)" id="geo-altitude" step="any"></cordova-number-entry>
     <cordova-number-entry label="Accuracy (m)" id="geo-accuracy" min="0" step="any"></cordova-number-entry>
     <cordova-number-entry label="Altitude accuracy (m)" id="geo-altitude-accuracy" min="0" step="any"></cordova-number-entry>
     <cordova-panel-row>
         <cordova-label label="Heading"></cordova-label>
         <cordova-label label="N" id="geo-heading-label"></cordova-label>
-        <input id="geo-heading" type="range" value="0" min="0" max="359.5" step="0.5" style="width:112px;">
+        <input id="geo-heading" type="range" value="0" min="0" max="359.99" step="any" style="width:112px;">
     </cordova-panel-row>
     <cordova-number-entry label="Speed (m/s)" id="geo-speed" min="0" step="any"></cordova-number-entry>
     <cordova-panel-row>

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -38,17 +38,17 @@
         </section>
     </cordova-panel-row>
 
-    <cordova-number-entry label="Latitude" id="geo-latitude"></cordova-number-entry>
-    <cordova-number-entry label="Longitude" id="geo-longitude"></cordova-number-entry>
-    <cordova-number-entry label="Altitude" id="geo-altitude"></cordova-number-entry>
-    <cordova-number-entry label="Accuracy" id="geo-accuracy"></cordova-number-entry>
-    <cordova-number-entry label="Altitude accuracy" id="geo-altitude-accuracy"></cordova-number-entry>
+    <cordova-number-entry label="Latitude" id="geo-latitude" step="any"></cordova-number-entry>
+    <cordova-number-entry label="Longitude" id="geo-longitude" step="any"></cordova-number-entry>
+    <cordova-number-entry label="Altitude (m)" id="geo-altitude" min="0" step="any"></cordova-number-entry>
+    <cordova-number-entry label="Accuracy (m)" id="geo-accuracy" min="0" step="any"></cordova-number-entry>
+    <cordova-number-entry label="Altitude accuracy (m)" id="geo-altitude-accuracy" min="0" step="any"></cordova-number-entry>
     <cordova-panel-row>
         <cordova-label label="Heading"></cordova-label>
         <cordova-label label="N" id="geo-heading-label"></cordova-label>
         <input id="geo-heading" type="range" value="0" min="0" max="359.5" step="0.5" style="width:112px;">
     </cordova-panel-row>
-    <cordova-number-entry label="Speed" id="geo-speed"></cordova-number-entry>
+    <cordova-number-entry label="Speed (m/s)" id="geo-speed" min="0" step="any"></cordova-number-entry>
     <cordova-panel-row>
         <cordova-label label="GPS Delay (seconds)"></cordova-label>
         <cordova-label label="0" id="geo-delay-label"></cordova-label>


### PR DESCRIPTION
Not all of the `cordova-number-entry` elements were configured properly according to the plugin API specification. This PR is to update the attribute configuration of `cordova-number-entry`, mostly for the geolocation widget.
This fix #117