### PR TITLE
Make compass 'wrapper size' multiple of 2

### DIFF
--- a/src/plugins/cordova-plugin-device-orientation/compass-widget.js
+++ b/src/plugins/cordova-plugin-device-orientation/compass-widget.js
@@ -20,7 +20,7 @@ function CompassWidget(options) {
     this._context = this._canvasElement.getContext('2d');
     this._diameter = (typeof options.diameter === 'number') ? options.diameter : CompassWidget.Defaults.DIAMETER;
 
-    this._wrapperSize = 25;
+    this._wrapperSize = 24;
     this._compassBorderSize = 15;
 
     this._canvasElement.style.position = 'absolute';


### PR DESCRIPTION
This determines how much bigger the background is compared to the compass. It needs to be a multiple of 2, since it is divided by 2 to determine the center point of the outer circle. At its previous value, the compass wasn't centered within that outer circle (12 pixels top and left, 13 pixels bottom and right).