### PR TITLE
Fix cordova-item delete button to work with themes.

### DIFF
--- a/src/sim-host/ui/sim-host-scaled.css
+++ b/src/sim-host/ui/sim-host-scaled.css
@@ -76,9 +76,9 @@ body /deep/ cordova-item + cordova-item {
     padding-top: 10px;
 }
 
-body /deep/ cordova-item:hover:before {
-    font-size: 14px;
-    padding-left: 8px;
+body /deep/ cordova-item /deep/ .close-button {
+    width: 17px;
+    height: 17px;
 }
 
 body /deep/ .cordova-collapse-icon svg,

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -91,7 +91,7 @@ cordova-button {
     overflow: visible;
 }
 
-cordova-button /deep/ button {
+body /deep/ button {
     width: 100%;
     padding: .4em 1em;
     cursor: pointer;
@@ -154,15 +154,16 @@ body /deep/ cordova-item + cordova-item {
     display: block;
 }
 
-body /deep/ cordova-item:hover:before {
-    content: url(delete.png);
+body /deep/ cordova-item /deep/ .close-button {
     position: absolute;
-    margin-left: auto;
+    top: 0;
     right: 0;
-    background: white;
-    font-weight: bold;
-    color: darkred;
-    cursor: pointer;
+    padding: 0;
+    display: none;
+}
+
+body /deep/ cordova-item:hover /deep/ .close-button {
+    display: block;
 }
 
 body /deep/ .cordova-collapse-icon,

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -43,7 +43,15 @@
     </template>
 
     <template id="cordova-item-template">
-        <content></content>
+        <section style="position: relative">
+            <content></content>
+            <button class="close-button">
+                <svg style="width:100%;height:100%" viewBox="0 0 14 14">
+                    <line x1="4" y1="4" x2="10" y2="10" stroke-width="1.5" stroke="currentColor"></line>
+                    <line x1="10" y1="4" x2="4" y2="10" stroke-width="1.5" stroke="currentColor"></line>
+                </svg>
+            </button>
+        </section>
     </template>
 
     <template id="cordova-panel-row-template">

--- a/src/sim-host/ui/theme.js
+++ b/src/sim-host/ui/theme.js
@@ -9,7 +9,7 @@ module.exports = {
             'input[type=range]::-moz-range-track'],
         'thumb': ['input[type=range]::-ms-thumb', 'input[type=range]::-webkit-slider-thumb','input[type=range]::-moz-range-thumb'],
         'check': '::-ms-check',
-        'button': 'cordova-button /deep/ button',
+        'button': 'body /deep/ button',
         'label': 'body /deep/ label',
         'value': 'body /deep/ .cordova-value',
         'panel': 'body /deep/ .cordova-panel-inner',


### PR DESCRIPTION
Old approach used a PNG and a fixed white background. This new approach uses a button (which will be styled with the current theme's button styling) with an SVG that will scale:

![image](https://cloud.githubusercontent.com/assets/9665847/19748899/a2a25d5e-9b99-11e6-8e7e-69f907de686b.png)

I think the result is actually nicer than we had before.