### PR TITLE
Some layout tweaks.

### DIFF
--- a/src/plugins/exec/sim-host-panels.html
+++ b/src/plugins/exec/sim-host-panels.html
@@ -1,8 +1,8 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
 <cordova-panel id="exec-panel" caption="Persisted Exec Calls" data-loc-id="983d0535">
-    <cordova-panel-row>
-        <cordova-label id="empty-label" class="cordova-hidden" label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
+    <cordova-panel-row id="empty-label" class="cordova-hidden">
+        <cordova-label label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
     </cordova-panel-row>
     <cordova-item-list id="exec-list" max-length="10"></cordova-item-list>
 </cordova-panel>

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -107,6 +107,11 @@ select::-ms-expand { /* for IE 11 */
     color: currentColor;
 }
 
+body /deep/ input[type=checkbox],
+body /deep/ input[type=radio] {
+    vertical-align: bottom;
+}
+
 body /deep/ input,
 body /deep/ textarea,
 body /deep/ select,


### PR DESCRIPTION
1. Checkbox in exec dialog wasn't vertically centered with its text.
2. "No values saved" was in a `cordova-panel-row` that was taking space even when the value was hidden. Hide the `cordova-panel-row` instead of the `cordova-label` element it contains.