### PR TITLE
Slider does not render properly in Edge

### DIFF
--- a/src/sim-host/ui/sim-host-scaled.css
+++ b/src/sim-host/ui/sim-host-scaled.css
@@ -112,9 +112,11 @@ input[type=range]::-ms-track {
     border-bottom: solid transparent 10px;
 }
 
+/* These properties !important to override -webkit-slider-thumb values in Edge */
 input[type=range]::-ms-thumb {
-    height: 18px;
-    width: 9px;
+    height: 18px !important;
+    width: 9px !important;
+    margin-top: 0 !important;
 }
 
 /* Style slider for Firefox */

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -224,10 +224,7 @@ input[type=range]::-ms-track {
     border-right: none;
 }
 
-body /deep/ input[type=range] {
-    -webkit-appearance: none;
-}
-
+body /deep/ input[type=range],
 body /deep/ input[type=range]::-webkit-slider-runnable-track,
 body /deep/ input[type=range]::-webkit-slider-thumb {
     -webkit-appearance: none;


### PR DESCRIPTION
Edge honors webkit prefixed CSS, including `-webkit-slider-thumb`. Unfortunately, we use `-webkit-slider-thumb` to style the slider thumb in ways specifically needed for Webkit, that break Edge. So set the `-ms-thumb` values to important to override.

Also, combine a couple of rules that defined the same property.