### PR TITLE
Allow a panel to get the focus, and spacebar to expand/collapse

### DIFF
--- a/src/server/theme.js
+++ b/src/server/theme.js
@@ -6,6 +6,8 @@ var crypto = require('crypto'),
     log = require('./utils/log'),
     utils = require('./utils/jsUtils');
 
+var selectorStateToken = '%state%';
+
 // Properties that will be applied from the set of default properties if they're not defined for an element. Themes
 // should define these properties on 'default' if they want them applied as defaults on the various element types.
 var appliedDefaultProperties = {
@@ -22,6 +24,8 @@ var appliedDefaultProperties = {
 
 // States that will be applied from the set of default states if they're not defined for an element
 var appliedDefaultStates = {
+    'panel': ['focus'],
+    'panel-caption': ['focus'],
     'button': ['hover', 'focus'],
     'input': ['hover', 'focus'],
     'thumb': ['hover', 'focus'],
@@ -229,14 +233,20 @@ function formatSelector(selector, state) {
 
 function appendState(selector, state) {
     if (!state) {
-        return selector;
+        return selector.replace(selectorStateToken, '');
     }
+
+    if (selector.indexOf(selectorStateToken) > -1) {
+        // If the selector specifies where the state should go, put it there
+        return selector.replace(selectorStateToken, ':' + state);
+    }
+
+    // Otherwise, Look for first pseudo-element in last selector - we want to put the state before that (so we're
+    // detecting state on the actual element, not the pseudo-element).
 
     // Split selector on whitespace
     selector = selector.split(/\s+/g);
 
-    // Look for first pseudo-element in last selector - we want to put the state before that (so we're detecting state
-    // on the actual element, not the pseudo-element).
     var idx = selector[selector.length - 1].indexOf('::');
     if (idx > -1) {
         selector[selector.length - 1] = selector[selector.length - 1].substring(0, idx) + ':' + state + selector[selector.length - 1].substring(idx);

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -28,7 +28,8 @@ function initialize(changePanelVisibilityCallback) {
             var collapseIcon = this.shadowRoot.querySelector('.cordova-collapse-icon');
 
             this.shadowRoot.querySelector('.cordova-header span').textContent = this.getAttribute('caption');
-            this.shadowRoot.querySelector('.cordova-header').addEventListener('click', function () {
+
+            function expandCollapse() {
                 var collapsed = collapseIcon.classList.contains('cordova-collapsed');
 
                 if (collapsed) {
@@ -39,6 +40,13 @@ function initialize(changePanelVisibilityCallback) {
 
                 if (changePanelVisibilityCallback && typeof changePanelVisibilityCallback === 'function') {
                     changePanelVisibilityCallback(panelId, !collapsed);
+                }
+            }
+
+            this.shadowRoot.querySelector('.cordova-header').addEventListener('click', expandCollapse);
+            this.shadowRoot.querySelector('.cordova-panel-inner').addEventListener('keydown', function (e) {
+                if (e.target === this && e.keyCode === 32 && !(e.altKey || e.ctrlKey || e.shiftKey)) {
+                    expandCollapse();
                 }
             });
         }

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -15,7 +15,7 @@
     <!-- For cordova-panel and cordova-dialog, the shadow is applied to the inner section, in order to prevent it
          getting cropped in Chrome when wrapping columns -->
     <template id="cordova-panel-template">
-        <section class="cordova-panel-inner">
+        <section class="cordova-panel-inner" tabindex="0">
             <section class="cordova-header"><span></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <polyline class="cordova-collapse-up" points="2,11 7,6 12,11" stroke-width="1.5" ></polyline>
                 <polyline class="cordova-collapse-down" points="2,6 7,11 12,6" stroke-width="1.5"></polyline>
@@ -27,7 +27,7 @@
     </template>
 
     <template id="cordova-dialog-template">
-        <section class="cordova-panel-inner">
+        <section class="cordova-panel-inner" tabindex="0">
             <section class="cordova-header"><span></span><span class="cordova-close-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <line x1="2" y1="4" x2="11" y2="13" stroke-width="1.5"></line>
                 <line x1="11" y1="4" x2="2" y2="13" stroke-width="1.5"></line>

--- a/src/sim-host/ui/theme.js
+++ b/src/sim-host/ui/theme.js
@@ -13,7 +13,7 @@ module.exports = {
         'label': 'body /deep/ label',
         'value': 'body /deep/ .cordova-value',
         'panel': 'body /deep/ .cordova-panel-inner',
-        'panel-caption': 'body /deep/ .cordova-header'
+        'panel-caption': 'body /deep/ .cordova-panel-inner%state% .cordova-header'
     },
 
     defaultTheme: {
@@ -54,6 +54,10 @@ module.exports = {
             '': {
                 'border': '1px solid rgba(0, 0, 0, 0.785)',
                 'background': 'rgba(255,255,255,0.97)'
+            },
+            'focus': {
+                'border': '1px solid rgb(128,128,128)',
+                'outline': 'none'
             }
         },
         'panel-caption': {
@@ -63,6 +67,10 @@ module.exports = {
                 'color': 'rgb(204,204,204)',
                 'text-transform': 'uppercase',
                 'font-weight': 'bold'
+            },
+            'focus': {
+                'background': 'rgb(128,128,128)',
+                'color': 'black'
             }
         },
         'thumb': {


### PR DESCRIPTION
Default theme, focus versus not focus:

![image](https://cloud.githubusercontent.com/assets/9665847/19783788/1bd1ab9a-9c48-11e6-8fdd-795365be1ac3.png)

(background color change isn't always necessary, but was here - border color changes just weren't obvious enough)