### PR TITLE
Make sure cordova-simulate works well with screen reader

### DIFF
--- a/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
@@ -1,16 +1,10 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
 <cordova-panel id="battery-status" caption="Battery Status" data-loc-id="ac1dbd34">
-    <style>
-        #battery-level-label {
-            margin-right: 5px;
-            margin-left: auto;
-        }
-    </style>
     <cordova-group>
         <cordova-panel-row>
-            <cordova-label label="Battery level" data-loc-id="e0d4e236"></cordova-label>
-            <cordova-label id="battery-level-label" label="100%"></cordova-label>
+            <cordova-label for="battery-level" label="Battery level" data-loc-id="e0d4e236"></cordova-label>
+            <cordova-label id="battery-level-label" label="100%" style="margin-right:5px;margin-left:auto;"></cordova-label>
             <input id="battery-level" type="range" value="100" min="0" max="100">
         </cordova-panel-row>
     </cordova-group>

--- a/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
@@ -1,22 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
-
+<link href="sim-host.css" rel="stylesheet">
 <cordova-panel id="device-motion" caption="Accelerometer" data-loc-id="9a8c8723">
-    <style>
-        #accelerometer-help {
-            font-size: 0.9em;
-            text-align: center;
-            padding: 1.5em 0;
-            margin-left: auto;
-            margin-right: auto;
-        }
-
-        #accelerometer-canvas {
-            display: block;
-            margin-left: auto;
-            margin-right: auto;
-        }
-    </style>
-
     <cordova-panel-row>
         <canvas id="accelerometer-canvas" width="200" height="160"></canvas>
     </cordova-panel-row>

--- a/src/plugins/cordova-plugin-device-motion/sim-host.css
+++ b/src/plugins/cordova-plugin-device-motion/sim-host.css
@@ -1,0 +1,13 @@
+#accelerometer-help {
+    font-size: 0.9em;
+    text-align: center;
+    padding: 1.5em 0;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+#accelerometer-canvas {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
@@ -1,25 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
-
+<link href="sim-host.css" rel="stylesheet">
 <cordova-panel id="device-orientation" caption="Compass" data-loc-id="8310fdf4">
-    <style>
-        #device-orientation #compass-widget {
-            margin: 0 auto;
-            position: relative;
-        }
-
-        #device-orientation [data-compass-heading="text"] {
-            margin-right: 5px;
-            margin-left: auto;
-        }
-
-        #device-orientation .compass-help-info em {
-            font-size: 0.9em;
-            text-align: center;
-            padding: 1.5em 0;
-            margin-left: auto;
-            margin-right: auto;
-        }
-    </style>
     <cordova-group>
         <cordova-panel-row>
             <div id="compass-widget">

--- a/src/plugins/cordova-plugin-device-orientation/sim-host.css
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host.css
@@ -1,0 +1,17 @@
+#device-orientation #compass-widget {
+    margin: 0 auto;
+    position: relative;
+}
+
+#device-orientation [data-compass-heading="text"] {
+    margin-right: 5px;
+    margin-left: auto;
+}
+
+#device-orientation .compass-help-info em {
+    font-size: 0.9em;
+    text-align: center;
+    padding: 1.5em 0;
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -6,12 +6,6 @@
 
 <!-- Panels -->
 <cordova-panel id="geolocation" caption="Geolocation" data-loc-id="e4b82624">
-    <style>
-        #geo-heading-label, #geo-delay-label {
-            margin-right: 5px;
-            margin-left: auto;
-        }
-    </style>
     <!-- Note that this needs to be a cordova-group not a cordova-panel-row as the flex box arranging of the latter
      screws up sizing of the map box in Firefox -->
     <cordova-group>
@@ -44,13 +38,13 @@
     <cordova-number-entry label="Accuracy (m)" id="geo-accuracy" min="0" step="any" data-loc-id="dbece2f9"></cordova-number-entry>
     <cordova-number-entry label="Altitude accuracy (m)" id="geo-altitude-accuracy" min="0" step="any" data-loc-id="718f25cb"></cordova-number-entry>
     <cordova-panel-row>
-        <cordova-label label="Heading" data-loc-id="64da0839"></cordova-label>
+        <cordova-label for="geo-heading" label="Heading" data-loc-id="64da0839"></cordova-label>
         <cordova-label label="N" id="geo-heading-label"></cordova-label>
         <input id="geo-heading" type="range" value="0" min="0" max="359.99" step="any">
     </cordova-panel-row>
     <cordova-number-entry label="Speed (m/s)" id="geo-speed" min="0" step="any" data-loc-id="8fefe84e"></cordova-number-entry>
     <cordova-panel-row>
-        <cordova-label label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
+        <cordova-label for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
         <cordova-label label="0" id="geo-delay-label"></cordova-label>
         <input id="geo-delay" type="range" value="0" min="0" max="30">
     </cordova-panel-row>

--- a/src/plugins/cordova-plugin-geolocation/sim-host.css
+++ b/src/plugins/cordova-plugin-geolocation/sim-host.css
@@ -100,3 +100,8 @@
 #geo-gpxreplaystatus:empty {
     display: none;
 }
+
+#geo-heading-label, #geo-delay-label {
+    margin-right: 5px;
+    margin-left: auto;
+}

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -183,7 +183,8 @@ function initialize(changePanelVisibilityCallback) {
                 // Reverse the order of the checkbox and caption
                 this.shadowRoot.appendChild(this.shadowRoot.querySelector('label'));
             }
-        }
+        },
+        mungeIds: 'cordova-checkbox-template-input'
     });
 
     registerCustomElement('cordova-radio', {
@@ -230,6 +231,8 @@ function initialize(changePanelVisibilityCallback) {
         },
         initialize: function () {
             this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');
+            this.shadowRoot.querySelector('label').setAttribute('for', this.getAttribute('for'));
+            this.setAttribute('for', '');
         }
     });
 


### PR DESCRIPTION
This change resolves a few issues when Windows Narrator reads out cordova-simulate interface.
1. Style tags are read out for a few plugins - change to inline CSS or move to css style sheet
2. Slider, or input type is range, does not have label associated - add "for" attribute to label so that it gets read out
3. Checkbox does not have label associated - add munge id when creating element so that the label gets read out