### PR TITLE
More enhancement on screen reader scenarios

### DIFF
--- a/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
@@ -3,11 +3,11 @@
 <cordova-panel id="battery-status" caption="Battery Status" panel-label="Battery Status Panel" data-loc-id="ac1dbd34">
     <cordova-group>
         <cordova-panel-row>
-            <cordova-label read-out="true" for="battery-level" label="Battery level" data-loc-id="e0d4e236"></cordova-label>
+            <cordova-label read-out for="battery-level" label="Battery level" data-loc-id="e0d4e236"></cordova-label>
             <cordova-label id="battery-level-label" label="100%" style="margin-right:5px;margin-left:auto;"></cordova-label>
             <input id="battery-level" type="range" value="100" min="0" max="100">
         </cordova-panel-row>
     </cordova-group>
 
-    <cordova-checkbox id="is-plugged" checked="" read-out="true" data-loc-id="10cfe833">Device plugged</cordova-checkbox>
+    <cordova-checkbox id="is-plugged" checked="" read-out data-loc-id="10cfe833">Device plugged</cordova-checkbox>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
@@ -3,11 +3,11 @@
 <cordova-panel id="battery-status" caption="Battery Status" panel-label="Battery Status Panel" data-loc-id="ac1dbd34">
     <cordova-group>
         <cordova-panel-row>
-            <cordova-label for="battery-level" label="Battery level" data-loc-id="e0d4e236"></cordova-label>
+            <cordova-label read-out="true" for="battery-level" label="Battery level" data-loc-id="e0d4e236"></cordova-label>
             <cordova-label id="battery-level-label" label="100%" style="margin-right:5px;margin-left:auto;"></cordova-label>
             <input id="battery-level" type="range" value="100" min="0" max="100">
         </cordova-panel-row>
     </cordova-group>
 
-    <cordova-checkbox id="is-plugged" checked="" data-loc-id="10cfe833">Device plugged</cordova-checkbox>
+    <cordova-checkbox id="is-plugged" checked="" read-out="true" data-loc-id="10cfe833">Device plugged</cordova-checkbox>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
@@ -1,13 +1,13 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="battery-status" caption="Battery Status" panel-label="Battery Status Panel" data-loc-id="ac1dbd34">
+<cordova-panel id="battery-status" caption="Battery Status" spoken-text="Battery Status Panel" data-loc-id="ac1dbd34">
     <cordova-group>
         <cordova-panel-row>
-            <cordova-label read-out for="battery-level" label="Battery level" data-loc-id="e0d4e236"></cordova-label>
+            <cordova-label spoken for="battery-level" label="Battery level" data-loc-id="e0d4e236"></cordova-label>
             <cordova-label id="battery-level-label" label="100%" style="margin-right:5px;margin-left:auto;"></cordova-label>
             <input id="battery-level" type="range" value="100" min="0" max="100">
         </cordova-panel-row>
     </cordova-group>
 
-    <cordova-checkbox id="is-plugged" checked="" read-out data-loc-id="10cfe833">Device plugged</cordova-checkbox>
+    <cordova-checkbox id="is-plugged" checked="" spoken data-loc-id="10cfe833">Device plugged</cordova-checkbox>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="battery-status" caption="Battery Status" data-loc-id="ac1dbd34">
+<cordova-panel id="battery-status" caption="Battery Status" panel-label="Battery Status Panel" data-loc-id="ac1dbd34">
     <cordova-group>
         <cordova-panel-row>
             <cordova-label for="battery-level" label="Battery level" data-loc-id="e0d4e236"></cordova-label>

--- a/src/plugins/cordova-plugin-camera/sim-host-dialogs.html
+++ b/src/plugins/cordova-plugin-camera/sim-host-dialogs.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-dialog id="camera-choose-image" caption="Camera: Choose Image" data-loc-id="5f1798d9">
+<cordova-dialog id="camera-choose-image" caption="Camera: Choose Image" panel-label="Camera: Choose Image diaglog" data-loc-id="5f1798d9">
     <section><img id="camera-dialog-image" style="width:100%; display: none;" src=""></section>
     <cordova-panel-row>
         <cordova-button id="camera-dialog-choose-filename" data-loc-id="030b9963">Choose File</cordova-button>

--- a/src/plugins/cordova-plugin-camera/sim-host-dialogs.html
+++ b/src/plugins/cordova-plugin-camera/sim-host-dialogs.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-dialog id="camera-choose-image" caption="Camera: Choose Image" panel-label="Camera: Choose Image diaglog" data-loc-id="5f1798d9">
+<cordova-dialog id="camera-choose-image" caption="Camera: Choose Image" spoken-text="Camera: Choose Image diaglog" data-loc-id="5f1798d9">
     <section><img id="camera-dialog-image" style="width:100%; display: none;" src=""></section>
     <cordova-panel-row>
         <cordova-button id="camera-dialog-choose-filename" data-loc-id="030b9963">Choose File</cordova-button>

--- a/src/plugins/cordova-plugin-camera/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-camera/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="camera" caption="Camera" data-loc-id="553fc9a5">
+<cordova-panel id="camera" caption="Camera" panel-label="Camera Panel" data-loc-id="553fc9a5">
     <cordova-group id="camera-options">
         <!--<cordova-radio id="camera-host">Use host system camera</cordova-radio>-->
         <cordova-radio id="camera-prompt" checked="true" data-loc-id="4f087d38">Prompt me for a file</cordova-radio>

--- a/src/plugins/cordova-plugin-camera/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-camera/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="camera" caption="Camera" panel-label="Camera Panel" data-loc-id="553fc9a5">
+<cordova-panel id="camera" caption="Camera" spoken-text="Camera Panel" data-loc-id="553fc9a5">
     <cordova-group id="camera-options">
         <!--<cordova-radio id="camera-host">Use host system camera</cordova-radio>-->
         <cordova-radio id="camera-prompt" checked="true" data-loc-id="4f087d38">Prompt me for a file</cordova-radio>

--- a/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 <link href="sim-host.css" rel="stylesheet">
-<cordova-panel id="device-motion" caption="Accelerometer" panel-label="Accelerometer Panel" data-loc-id="9a8c8723">
+<cordova-panel id="device-motion" caption="Accelerometer" spoken-text="Accelerometer Panel" data-loc-id="9a8c8723">
     <cordova-panel-row>
         <canvas id="accelerometer-canvas" width="200" height="160"></canvas>
     </cordova-panel-row>
@@ -9,12 +9,12 @@
         <em id="accelerometer-help" aria-hidden="true" data-loc-id="c562ff87">Click and drag with the mouse to manipulate the device. <br> Hold the Shift key to modify 'alpha'</em>
     </cordova-panel-row>
 
-    <cordova-labeled-value id="accel-x" label="X (m/s²)" read-label="X meters per second squared" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-y" label="Y (m/s²)" read-label="Y meters per second squared" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-z" label="Z (m/s²)" read-label="Z meters per second squared" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-alpha" label="alpha (deg)" read-label="alpha degree" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-beta" label="beta (deg)" read-label="beta degree"value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-gamma" label="gamma (deg)" read-label="gamma degree" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-x" label="X (m/s²)" spoken-text="X (meters per second squared)" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-y" label="Y (m/s²)" spoken-text="Y (meters per second squared)" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-z" label="Z (m/s²)" spoken-text="Z (meters per second squared)" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-alpha" label="alpha (deg)" spoken-text="alpha (degree)" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-beta" label="beta (deg)" spoken-text="beta (degree)"value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-gamma" label="gamma (deg)" spoken-text="gamma (degree)" value="0"></cordova-labeled-value>
 
     <cordova-combo id="accel-recorded-data" label="Recorded Data" data-loc-id="d240cacf"></cordova-combo>
     <cordova-panel-row><cordova-button id="accel-play-recorded" data-loc-id="1b009684">Play</cordova-button></cordova-panel-row>

--- a/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 <link href="sim-host.css" rel="stylesheet">
-<cordova-panel id="device-motion" caption="Accelerometer" data-loc-id="9a8c8723">
+<cordova-panel id="device-motion" caption="Accelerometer" panel-label="Accelerometer Panel" data-loc-id="9a8c8723">
     <cordova-panel-row>
         <canvas id="accelerometer-canvas" width="200" height="160"></canvas>
     </cordova-panel-row>

--- a/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
@@ -9,12 +9,12 @@
         <em id="accelerometer-help" aria-hidden="true" data-loc-id="c562ff87">Click and drag with the mouse to manipulate the device. <br> Hold the Shift key to modify 'alpha'</em>
     </cordova-panel-row>
 
-    <cordova-labeled-value id="accel-x" label="X (m/s²)" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-y" label="Y (m/s²)" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-z" label="Z (m/s²)" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-alpha" label="alpha (deg)" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-beta" label="beta (deg)" value="0"></cordova-labeled-value>
-    <cordova-labeled-value id="accel-gamma" label="gamma (deg)" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-x" label="X (m/s²)" read-label="X meters per second squared" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-y" label="Y (m/s²)" read-label="Y meters per second squared" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-z" label="Z (m/s²)" read-label="Z meters per second squared" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-alpha" label="alpha (deg)" read-label="alpha degree" value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-beta" label="beta (deg)" read-label="beta degree"value="0"></cordova-labeled-value>
+    <cordova-labeled-value id="accel-gamma" label="gamma (deg)" read-label="gamma degree" value="0"></cordova-labeled-value>
 
     <cordova-combo id="accel-recorded-data" label="Recorded Data" data-loc-id="d240cacf"></cordova-combo>
     <cordova-panel-row><cordova-button id="accel-play-recorded" data-loc-id="1b009684">Play</cordova-button></cordova-panel-row>

--- a/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
@@ -12,9 +12,9 @@
     <cordova-number-entry id="accel-x" label="X (m/s²)" spoken-text="X (meters per second squared)" value="0" step="any"></cordova-number-entry>
     <cordova-number-entry id="accel-y" label="Y (m/s²)" spoken-text="Y (meters per second squared)" value="0" step="any"></cordova-number-entry>
     <cordova-number-entry id="accel-z" label="Z (m/s²)" spoken-text="Z (meters per second squared)" value="0" step="any"></cordova-number-entry>
-    <cordova-number-entry id="accel-alpha" label="alpha (deg)" spoken-text="alpha (degree)" value="0" min="0" max="360" step="1"></cordova-number-entry>
-    <cordova-number-entry id="accel-beta" label="beta (deg)" spoken-text="beta (degree)" value="0" min="-180" max="180" step="1"></cordova-number-entry>
-    <cordova-number-entry id="accel-gamma" label="gamma (deg)" spoken-text="gamma (degree)" value="0" min="-90" max="90" step="1"></cordova-number-entry>
+    <cordova-number-entry id="accel-alpha" label="alpha (deg)" spoken-text="alpha (degrees)" value="0" min="0" max="360" step="1"></cordova-number-entry>
+    <cordova-number-entry id="accel-beta" label="beta (deg)" spoken-text="beta (degrees)" value="0" min="-180" max="180" step="1"></cordova-number-entry>
+    <cordova-number-entry id="accel-gamma" label="gamma (deg)" spoken-text="gamma (degrees)" value="0" min="-90" max="90" step="1"></cordova-number-entry>
 
     <cordova-combo id="accel-recorded-data" label="Recorded Data" data-loc-id="d240cacf"></cordova-combo>
     <cordova-panel-row><cordova-button id="accel-play-recorded" data-loc-id="1b009684">Play</cordova-button></cordova-panel-row>

--- a/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-motion/sim-host-panels.html
@@ -6,7 +6,7 @@
     </cordova-panel-row>
 
     <cordova-panel-row>
-        <em id="accelerometer-help" data-loc-id="c562ff87">Click and drag with the mouse to manipulate the device. <br> Hold the Shift key to modify 'alpha'</em>
+        <em id="accelerometer-help" aria-hidden="true" data-loc-id="c562ff87">Click and drag with the mouse to manipulate the device. <br> Hold the Shift key to modify 'alpha'</em>
     </cordova-panel-row>
 
     <cordova-labeled-value id="accel-x" label="X (m/s²)" value="0"></cordova-labeled-value>

--- a/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
@@ -40,13 +40,13 @@
         </cordova-panel-row>
 
         <cordova-panel-row class="compass-help-info" data-loc-id="c4c80de2">
-            <em>Click and drag with the mouse to manipulate the device compass.</em>
+            <em aria-hidden="true">Click and drag with the mouse to manipulate the device compass.</em>
         </cordova-panel-row>
     </cordova-group>
 
     <cordova-group>
         <cordova-panel-row>
-            <label for="compass-heading-value" data-loc-id="ae47e3ec">Heading (deg)</label>
+            <label aria-hidden="true" for="compass-heading-value" data-loc-id="ae47e3ec">Heading (deg)</label>
             <label data-compass-heading="text">N</label>
             <input type="number" id="compass-heading-value" min="0" max="359.99" step="any">
         </cordova-panel-row>

--- a/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 <link href="sim-host.css" rel="stylesheet">
-<cordova-panel id="device-orientation" caption="Compass" panel-label="Compass Panel" data-loc-id="8310fdf4">
+<cordova-panel id="device-orientation" caption="Compass" spoken-text="Compass Panel" data-loc-id="8310fdf4">
     <cordova-group>
         <cordova-panel-row>
             <div id="compass-widget">

--- a/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 <link href="sim-host.css" rel="stylesheet">
-<cordova-panel id="device-orientation" caption="Compass" data-loc-id="8310fdf4">
+<cordova-panel id="device-orientation" caption="Compass" panel-label="Compass Panel" data-loc-id="8310fdf4">
     <cordova-group>
         <cordova-panel-row>
             <div id="compass-widget">

--- a/src/plugins/cordova-plugin-device/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device/sim-host-panels.html
@@ -13,5 +13,5 @@
     <cordova-labeled-value label="UUID" id="device-uuid" data-loc-id="f443efdd"></cordova-labeled-value>
     <cordova-labeled-value label="Version" id="device-version" data-loc-id="43cf4836"></cordova-labeled-value>
     <cordova-labeled-value label="Serial" id="device-serial" data-loc-id="bcc45f6d"></cordova-labeled-value>
-    <cordova-checkbox id="is-virtual-device" read-out="true" data-loc-id="c1a21524">Virtual device</cordova-checkbox>
+    <cordova-checkbox id="is-virtual-device" read-out data-loc-id="c1a21524">Virtual device</cordova-checkbox>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-device/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="device" caption="Device" data-loc-id="c045b281">
+<cordova-panel id="device" caption="Device" panel-label="Device Panel" data-loc-id="c045b281">
     <cordova-labeled-value id="device-platform" label="Platform" data-loc-id="db946bb7"></cordova-labeled-value>
     <cordova-combo id="device-list" label="Device" data-loc-id="7f7c31ee"></cordova-combo>
     <cordova-combo id="device-os-version" label="OS version" style="display:none;" data-loc-id="39a39347"></cordova-combo>

--- a/src/plugins/cordova-plugin-device/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="device" caption="Device" panel-label="Device Panel" data-loc-id="c045b281">
+<cordova-panel id="device" caption="Device" spoken-text="Device Panel" data-loc-id="c045b281">
     <cordova-labeled-value id="device-platform" label="Platform" data-loc-id="db946bb7"></cordova-labeled-value>
     <cordova-combo id="device-list" label="Device" data-loc-id="7f7c31ee"></cordova-combo>
     <cordova-combo id="device-os-version" label="OS version" style="display:none;" data-loc-id="39a39347"></cordova-combo>
@@ -13,5 +13,5 @@
     <cordova-labeled-value label="UUID" id="device-uuid" data-loc-id="f443efdd"></cordova-labeled-value>
     <cordova-labeled-value label="Version" id="device-version" data-loc-id="43cf4836"></cordova-labeled-value>
     <cordova-labeled-value label="Serial" id="device-serial" data-loc-id="bcc45f6d"></cordova-labeled-value>
-    <cordova-checkbox id="is-virtual-device" read-out data-loc-id="c1a21524">Virtual device</cordova-checkbox>
+    <cordova-checkbox id="is-virtual-device" spoken data-loc-id="c1a21524">Virtual device</cordova-checkbox>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-device/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device/sim-host-panels.html
@@ -13,5 +13,5 @@
     <cordova-labeled-value label="UUID" id="device-uuid" data-loc-id="f443efdd"></cordova-labeled-value>
     <cordova-labeled-value label="Version" id="device-version" data-loc-id="43cf4836"></cordova-labeled-value>
     <cordova-labeled-value label="Serial" id="device-serial" data-loc-id="bcc45f6d"></cordova-labeled-value>
-    <cordova-checkbox id="is-virtual-device" data-loc-id="c1a21524">Virtual device</cordova-checkbox>
+    <cordova-checkbox id="is-virtual-device" read-out="true" data-loc-id="c1a21524">Virtual device</cordova-checkbox>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -46,7 +46,7 @@
     <cordova-panel-row>
         <cordova-label for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
         <cordova-label label="0" id="geo-delay-label"></cordova-label>
-        <input aria-hidden="true" id="geo-delay" type="range" value="0" min="0" max="30">
+        <input id="geo-delay" type="range" value="0" min="0" max="30">
     </cordova-panel-row>
     <cordova-checkbox id="geo-timeout" data-loc-id="b2d5a0cc">Simulate GPS Timeout</cordova-checkbox>
 

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -38,20 +38,20 @@
     <cordova-number-entry label="Accuracy (m)" read-label="Accuracy meters" id="geo-accuracy" min="0" step="any" data-loc-id="dbece2f9"></cordova-number-entry>
     <cordova-number-entry label="Altitude accuracy (m)" read-label="Altitude accuracy meters" id="geo-altitude-accuracy" min="0" step="any" data-loc-id="718f25cb"></cordova-number-entry>
     <cordova-panel-row>
-        <cordova-label for="geo-heading" read-out="true" label="Heading" data-loc-id="64da0839"></cordova-label>
-        <cordova-label label="N" read-out="true" id="geo-heading-label"></cordova-label>
+        <cordova-label for="geo-heading" read-out label="Heading" data-loc-id="64da0839"></cordova-label>
+        <cordova-label label="N" read-out id="geo-heading-label"></cordova-label>
         <input id="geo-heading" type="range" value="0" min="0" max="359.99" step="any">
     </cordova-panel-row>
     <cordova-number-entry label="Speed (m/s)" read-label="Speed meters per second" id="geo-speed" min="0" step="any" data-loc-id="8fefe84e"></cordova-number-entry>
     <cordova-panel-row>
-        <cordova-label read-out="true" for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
+        <cordova-label read-out for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
         <cordova-label label="0" id="geo-delay-label"></cordova-label>
         <input id="geo-delay" type="range" value="0" min="0" max="30">
     </cordova-panel-row>
     <cordova-checkbox id="geo-timeout" data-loc-id="b2d5a0cc">Simulate GPS Timeout</cordova-checkbox>
 
     <cordova-panel-row>
-        <cordova-label label="Navigation Simulator" read-out="true" data-loc-id="f89bb5e3"></cordova-label>
+        <cordova-label label="Navigation Simulator" read-out data-loc-id="f89bb5e3"></cordova-label>
     </cordova-panel-row>
     <cordova-panel-row>
         <section>

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -9,7 +9,7 @@
     <!-- Note that this needs to be a cordova-group not a cordova-panel-row as the flex box arranging of the latter
      screws up sizing of the map box in Firefox -->
     <cordova-group>
-        <div class="geo-box">
+        <div aria-hidden="true" class="geo-box">
             <div class="geo-content">
                 <div id="geo-map-container"></div>
                 <div id="geo-map-marker"></div>
@@ -46,7 +46,7 @@
     <cordova-panel-row>
         <cordova-label for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
         <cordova-label label="0" id="geo-delay-label"></cordova-label>
-        <input id="geo-delay" type="range" value="0" min="0" max="30">
+        <input aria-hidden="true" id="geo-delay" type="range" value="0" min="0" max="30">
     </cordova-panel-row>
     <cordova-checkbox id="geo-timeout" data-loc-id="b2d5a0cc">Simulate GPS Timeout</cordova-checkbox>
 

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -23,8 +23,8 @@
     </cordova-group>
     <cordova-panel-row>
         <section>
-        <cordova-button id="geo-map-zoom-decrease" style="min-width:0;">-</cordova-button>
-        <cordova-button id="geo-map-zoom-increase" style="min-width:0;">+</cordova-button>
+        <cordova-button id="geo-map-zoom-decrease" read-label="zoom map out" style="min-width:0;">-</cordova-button>
+        <cordova-button id="geo-map-zoom-increase" read-label="zoom map in" style="min-width:0;">+</cordova-button>
         </section>
         <section class="geo-map-zoomlevel" data-loc-id="7e9696b6">
             Zoom Level:&nbsp;
@@ -34,24 +34,24 @@
 
     <cordova-number-entry label="Latitude" id="geo-latitude" step="any" data-loc-id="41fd30cf"></cordova-number-entry>
     <cordova-number-entry label="Longitude" id="geo-longitude" step="any" data-loc-id="9db6eee1"></cordova-number-entry>
-    <cordova-number-entry label="Altitude (m)" id="geo-altitude" step="any" data-loc-id="079f55f6"></cordova-number-entry>
-    <cordova-number-entry label="Accuracy (m)" id="geo-accuracy" min="0" step="any" data-loc-id="dbece2f9"></cordova-number-entry>
-    <cordova-number-entry label="Altitude accuracy (m)" id="geo-altitude-accuracy" min="0" step="any" data-loc-id="718f25cb"></cordova-number-entry>
+    <cordova-number-entry label="Altitude (m)" read-label="Altitude meters" id="geo-altitude" step="any" data-loc-id="079f55f6"></cordova-number-entry>
+    <cordova-number-entry label="Accuracy (m)" read-label="Accuracy meters" id="geo-accuracy" min="0" step="any" data-loc-id="dbece2f9"></cordova-number-entry>
+    <cordova-number-entry label="Altitude accuracy (m)" read-label="Altitude accuracy meters" id="geo-altitude-accuracy" min="0" step="any" data-loc-id="718f25cb"></cordova-number-entry>
     <cordova-panel-row>
-        <cordova-label for="geo-heading" label="Heading" data-loc-id="64da0839"></cordova-label>
-        <cordova-label label="N" id="geo-heading-label"></cordova-label>
+        <cordova-label for="geo-heading" read-out="true" label="Heading" data-loc-id="64da0839"></cordova-label>
+        <cordova-label label="N" read-out="true" id="geo-heading-label"></cordova-label>
         <input id="geo-heading" type="range" value="0" min="0" max="359.99" step="any">
     </cordova-panel-row>
-    <cordova-number-entry label="Speed (m/s)" id="geo-speed" min="0" step="any" data-loc-id="8fefe84e"></cordova-number-entry>
+    <cordova-number-entry label="Speed (m/s)" read-label="Speed meters per second" id="geo-speed" min="0" step="any" data-loc-id="8fefe84e"></cordova-number-entry>
     <cordova-panel-row>
-        <cordova-label for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
+        <cordova-label read-out="true" for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
         <cordova-label label="0" id="geo-delay-label"></cordova-label>
         <input id="geo-delay" type="range" value="0" min="0" max="30">
     </cordova-panel-row>
     <cordova-checkbox id="geo-timeout" data-loc-id="b2d5a0cc">Simulate GPS Timeout</cordova-checkbox>
 
     <cordova-panel-row>
-        <cordova-label label="Navigation Simulator" data-loc-id="f89bb5e3"></cordova-label>
+        <cordova-label label="Navigation Simulator" read-out="true" data-loc-id="f89bb5e3"></cordova-label>
     </cordova-panel-row>
     <cordova-panel-row>
         <section>

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -5,7 +5,7 @@
 <link href="sim-host.css" rel="stylesheet">
 
 <!-- Panels -->
-<cordova-panel id="geolocation" caption="Geolocation" panel-label="Geolocation Panel" data-loc-id="e4b82624">
+<cordova-panel id="geolocation" caption="Geolocation" spoken-text="Geolocation Panel" data-loc-id="e4b82624">
     <!-- Note that this needs to be a cordova-group not a cordova-panel-row as the flex box arranging of the latter
      screws up sizing of the map box in Firefox -->
     <cordova-group>
@@ -23,8 +23,8 @@
     </cordova-group>
     <cordova-panel-row>
         <section>
-        <cordova-button id="geo-map-zoom-decrease" read-label="zoom map out" style="min-width:0;">-</cordova-button>
-        <cordova-button id="geo-map-zoom-increase" read-label="zoom map in" style="min-width:0;">+</cordova-button>
+        <cordova-button id="geo-map-zoom-decrease" spoken-text="zoom map out" style="min-width:0;">-</cordova-button>
+        <cordova-button id="geo-map-zoom-increase" spoken-text="zoom map in" style="min-width:0;">+</cordova-button>
         </section>
         <section class="geo-map-zoomlevel" data-loc-id="7e9696b6">
             Zoom Level:&nbsp;
@@ -34,24 +34,24 @@
 
     <cordova-number-entry label="Latitude" id="geo-latitude" step="any" data-loc-id="41fd30cf"></cordova-number-entry>
     <cordova-number-entry label="Longitude" id="geo-longitude" step="any" data-loc-id="9db6eee1"></cordova-number-entry>
-    <cordova-number-entry label="Altitude (m)" read-label="Altitude meters" id="geo-altitude" step="any" data-loc-id="079f55f6"></cordova-number-entry>
-    <cordova-number-entry label="Accuracy (m)" read-label="Accuracy meters" id="geo-accuracy" min="0" step="any" data-loc-id="dbece2f9"></cordova-number-entry>
-    <cordova-number-entry label="Altitude accuracy (m)" read-label="Altitude accuracy meters" id="geo-altitude-accuracy" min="0" step="any" data-loc-id="718f25cb"></cordova-number-entry>
+    <cordova-number-entry label="Altitude (m)" spoken-text="Altitude (meters)" id="geo-altitude" step="any" data-loc-id="079f55f6"></cordova-number-entry>
+    <cordova-number-entry label="Accuracy (m)" spoken-text="Accuracy (meters)" id="geo-accuracy" min="0" step="any" data-loc-id="dbece2f9"></cordova-number-entry>
+    <cordova-number-entry label="Altitude accuracy (m)" spoken-text="Altitude accuracy (meters)" id="geo-altitude-accuracy" min="0" step="any" data-loc-id="718f25cb"></cordova-number-entry>
     <cordova-panel-row>
-        <cordova-label for="geo-heading" read-out label="Heading" data-loc-id="64da0839"></cordova-label>
-        <cordova-label label="N" read-out id="geo-heading-label"></cordova-label>
+        <cordova-label for="geo-heading" spoken label="Heading" data-loc-id="64da0839"></cordova-label>
+        <cordova-label label="N" spoken id="geo-heading-label"></cordova-label>
         <input id="geo-heading" type="range" value="0" min="0" max="359.99" step="any">
     </cordova-panel-row>
-    <cordova-number-entry label="Speed (m/s)" read-label="Speed meters per second" id="geo-speed" min="0" step="any" data-loc-id="8fefe84e"></cordova-number-entry>
+    <cordova-number-entry label="Speed (m/s)" spoken-text="Speed (meters per second)" id="geo-speed" min="0" step="any" data-loc-id="8fefe84e"></cordova-number-entry>
     <cordova-panel-row>
-        <cordova-label read-out for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
+        <cordova-label spoken for="geo-delay" label="GPS Delay (seconds)" data-loc-id="42557ee2"></cordova-label>
         <cordova-label label="0" id="geo-delay-label"></cordova-label>
         <input id="geo-delay" type="range" value="0" min="0" max="30">
     </cordova-panel-row>
     <cordova-checkbox id="geo-timeout" data-loc-id="b2d5a0cc">Simulate GPS Timeout</cordova-checkbox>
 
     <cordova-panel-row>
-        <cordova-label label="Navigation Simulator" read-out data-loc-id="f89bb5e3"></cordova-label>
+        <cordova-label label="Navigation Simulator" spoken data-loc-id="f89bb5e3"></cordova-label>
     </cordova-panel-row>
     <cordova-panel-row>
         <section>

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -5,7 +5,7 @@
 <link href="sim-host.css" rel="stylesheet">
 
 <!-- Panels -->
-<cordova-panel id="geolocation" caption="Geolocation" data-loc-id="e4b82624">
+<cordova-panel id="geolocation" caption="Geolocation" panel-label="Geolocation Panel" data-loc-id="e4b82624">
     <!-- Note that this needs to be a cordova-group not a cordova-panel-row as the flex box arranging of the latter
      screws up sizing of the map box in Firefox -->
     <cordova-group>

--- a/src/plugins/cordova-plugin-globalization/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-globalization/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="globalization" caption="Globalization" panel-label="Globalization Panel" data-loc-id="5ffc4b1e">
+<cordova-panel id="globalization" caption="Globalization" spoken-text="Globalization Panel" data-loc-id="5ffc4b1e">
     <cordova-combo id="locale-list" label="Select the locale:" data-loc-id="9e831385"></cordova-combo>
     <cordova-checkbox id="is-daylight-checkbox" data-loc-id="24aa60d4">Is daylight saving time</cordova-checkbox>
     <cordova-combo id="day-list" label="Select the first day of the week:" data-loc-id="ee1bad9c"></cordova-combo>

--- a/src/plugins/cordova-plugin-globalization/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-globalization/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="globalization" caption="Globalization" data-loc-id="5ffc4b1e">
+<cordova-panel id="globalization" caption="Globalization" panel-label="Globalization Panel" data-loc-id="5ffc4b1e">
     <cordova-combo id="locale-list" label="Select the locale:" data-loc-id="9e831385"></cordova-combo>
     <cordova-checkbox id="is-daylight-checkbox" data-loc-id="24aa60d4">Is daylight saving time</cordova-checkbox>
     <cordova-combo id="day-list" label="Select the first day of the week:" data-loc-id="ee1bad9c"></cordova-combo>

--- a/src/plugins/cordova-plugin-inappbrowser/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-inappbrowser/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="inappbrowser" caption="InAppBrowser" data-loc-id="4c1114ef">
+<cordova-panel id="inappbrowser" caption="InAppBrowser" panel-label="InAppBrowser Panel" data-loc-id="4c1114ef">
     <cordova-panel-row>
         <label data-loc-id="99399f4d">Select the default behaviour of InAppBrowser when opening using the <em>_blank</em> target</label>
     </cordova-panel-row>

--- a/src/plugins/cordova-plugin-inappbrowser/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-inappbrowser/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="inappbrowser" caption="InAppBrowser" panel-label="InAppBrowser Panel" data-loc-id="4c1114ef">
+<cordova-panel id="inappbrowser" caption="InAppBrowser" spoken-text="InAppBrowser Panel" data-loc-id="4c1114ef">
     <cordova-panel-row>
         <label data-loc-id="99399f4d">Select the default behaviour of InAppBrowser when opening using the <em>_blank</em> target</label>
     </cordova-panel-row>

--- a/src/plugins/cordova-plugin-network-information/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-network-information/sim-host-panels.html
@@ -1,5 +1,5 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="network-information" caption="Network Connection" data-loc-id="a4a98056">
+<cordova-panel id="network-information" caption="Network Connection" panel-label="Network Connection Panel" data-loc-id="a4a98056">
     <cordova-combo id="connection-list" label="Connection type" data-loc-id="27c4a479"></cordova-combo>
 </cordova-panel>

--- a/src/plugins/cordova-plugin-network-information/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-network-information/sim-host-panels.html
@@ -1,5 +1,5 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="network-information" caption="Network Connection" panel-label="Network Connection Panel" data-loc-id="a4a98056">
+<cordova-panel id="network-information" caption="Network Connection" spoken-text="Network Connection Panel" data-loc-id="a4a98056">
     <cordova-combo id="connection-list" label="Connection type" data-loc-id="27c4a479"></cordova-combo>
 </cordova-panel>

--- a/src/plugins/events/sim-host-panels.html
+++ b/src/plugins/events/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="events" caption="Events" data-loc-id="c9b16703">
+<cordova-panel id="events" caption="Events" panel-label="Events Panel" data-loc-id="c9b16703">
     <cordova-combo id="event-list" label="Select the event to fire:" data-loc-id="4eb9640f"></cordova-combo>
     <cordova-panel-row><cordova-button id="event-fire" data-loc-id="064dde5f">Fire Event</cordova-button></cordova-panel-row>
 </cordova-panel>

--- a/src/plugins/events/sim-host-panels.html
+++ b/src/plugins/events/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="events" caption="Events" panel-label="Events Panel" data-loc-id="c9b16703">
+<cordova-panel id="events" caption="Events" spoken-text="Events Panel" data-loc-id="c9b16703">
     <cordova-combo id="event-list" label="Select the event to fire:" data-loc-id="4eb9640f"></cordova-combo>
     <cordova-panel-row><cordova-button id="event-fire" data-loc-id="064dde5f">Fire Event</cordova-button></cordova-panel-row>
 </cordova-panel>

--- a/src/plugins/exec/sim-host-panels.html
+++ b/src/plugins/exec/sim-host-panels.html
@@ -2,7 +2,7 @@
 
 <cordova-panel id="exec-panel" caption="Persisted Exec Calls" panel-label="Persisted Exec Calls Panel" data-loc-id="983d0535">
     <cordova-panel-row id="empty-label" class="cordova-hidden">
-        <cordova-label label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
+        <cordova-label read-out="true" label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
     </cordova-panel-row>
     <cordova-item-list id="exec-list" max-length="10"></cordova-item-list>
 </cordova-panel>

--- a/src/plugins/exec/sim-host-panels.html
+++ b/src/plugins/exec/sim-host-panels.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="exec-panel" caption="Persisted Exec Calls" data-loc-id="983d0535">
+<cordova-panel id="exec-panel" caption="Persisted Exec Calls" panel-label="Persisted Exec Calls Panel" data-loc-id="983d0535">
     <cordova-panel-row id="empty-label" class="cordova-hidden">
         <cordova-label label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
     </cordova-panel-row>

--- a/src/plugins/exec/sim-host-panels.html
+++ b/src/plugins/exec/sim-host-panels.html
@@ -2,7 +2,7 @@
 
 <cordova-panel id="exec-panel" caption="Persisted Exec Calls" panel-label="Persisted Exec Calls Panel" data-loc-id="983d0535">
     <cordova-panel-row id="empty-label" class="cordova-hidden">
-        <cordova-label read-out="true" label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
+        <cordova-label read-out label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
     </cordova-panel-row>
     <cordova-item-list id="exec-list" max-length="10"></cordova-item-list>
 </cordova-panel>

--- a/src/plugins/exec/sim-host-panels.html
+++ b/src/plugins/exec/sim-host-panels.html
@@ -1,8 +1,8 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
 
-<cordova-panel id="exec-panel" caption="Persisted Exec Calls" panel-label="Persisted Exec Calls Panel" data-loc-id="983d0535">
+<cordova-panel id="exec-panel" caption="Persisted Exec Calls" spoken-text="Persisted Exec Calls Panel" data-loc-id="983d0535">
     <cordova-panel-row id="empty-label" class="cordova-hidden">
-        <cordova-label read-out label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
+        <cordova-label spoken label="No values saved" data-loc-id="b58dd0ca"></cordova-label>
     </cordova-panel-row>
     <cordova-item-list id="exec-list" max-length="10"></cordova-item-list>
 </cordova-panel>

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -54,8 +54,8 @@ function initialize(changePanelVisibilityCallback) {
             var collapseIcon = this.shadowRoot.querySelector('.cordova-collapse-icon');
 
             this.shadowRoot.querySelector('.cordova-header .spoken-text span').textContent = this.getAttribute('caption');
-            this.shadowRoot.querySelector('.cordova-header .spoken-text').setAttribute('aria-label', this.getAttribute('spoken-text'));
-            
+            this.shadowRoot.querySelector('.cordova-header .spoken-text').setAttribute('aria-label', this.getAttribute('spoken-text') || this.getAttribute('caption'));
+
             function expandCollapse() {
                 var collapsed = collapseIcon.classList.contains('cordova-collapsed');
 
@@ -85,12 +85,6 @@ function initialize(changePanelVisibilityCallback) {
                 value: function () {
                     document.getElementById('popup-window').style.display = '';
                     this.style.display = '';
-
-                    // Set focus to first focusable element in panel (simplistic until we need otherwise).
-                    var focusElement = this.querySelector(interactiveElementSelector);
-                    if (focusElement) {
-                        focusElement.focus();
-                    }
                     this.querySelector('.cordova-panel-inner').focus();
                 }
             },
@@ -103,7 +97,7 @@ function initialize(changePanelVisibilityCallback) {
         },
         initialize: function () {
             this.shadowRoot.querySelector('.cordova-header .spoken-text span').textContent = this.getAttribute('caption');
-            this.shadowRoot.querySelector('.cordova-header .spoken-text').setAttribute('aria-label', this.getAttribute('spoken-text'));
+            this.shadowRoot.querySelector('.cordova-header .spoken-text').setAttribute('aria-label', this.getAttribute('spoken-text') || this.getAttribute('caption'));
 
             this.shadowRoot.querySelector('.cordova-close-icon').addEventListener('click', function () {
                 dialog.hideDialog();
@@ -395,12 +389,7 @@ function initialize(changePanelVisibilityCallback) {
             this._internalValue = 0;
 
             var input = this.shadowRoot.querySelector('input');
-            var readLabel = this.getAttribute('spoken-text');
-            if (readLabel) {
-                input.setAttribute('aria-label', readLabel);
-            } else {
-                input.setAttribute('aria-label', displayLabel);
-            }
+            input.setAttribute('aria-label', this.getAttribute('spoken-text') || displayLabel);
 
             var maxValue = this.getAttribute('max'),
                 minValue = this.getAttribute('min'),
@@ -462,7 +451,7 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            this.shadowRoot.querySelector('label').textContent = this.getAttribute('label'); 
+            this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');
             this.shadowRoot.querySelector('span').textContent = this.getAttribute('value');
             this.classList.add('cordova-panel-row');
             this.classList.add('cordova-group');

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -53,8 +53,8 @@ function initialize(changePanelVisibilityCallback) {
             var panelId = this.getAttribute('id');
             var collapseIcon = this.shadowRoot.querySelector('.cordova-collapse-icon');
 
-            this.shadowRoot.querySelector('.cordova-header .panel-label span').textContent = this.getAttribute('caption');
-            this.shadowRoot.querySelector('.cordova-header .panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
+            this.shadowRoot.querySelector('.cordova-header .spoken-text span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header .spoken-text').setAttribute('aria-label', this.getAttribute('spoken-text'));
             
             function expandCollapse() {
                 var collapsed = collapseIcon.classList.contains('cordova-collapsed');
@@ -102,8 +102,8 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            this.shadowRoot.querySelector('.cordova-header .panel-label span').textContent = this.getAttribute('caption');
-            this.shadowRoot.querySelector('.cordova-header .panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
+            this.shadowRoot.querySelector('.cordova-header .spoken-text span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header .spoken-text').setAttribute('aria-label', this.getAttribute('spoken-text'));
 
             this.shadowRoot.querySelector('.cordova-close-icon').addEventListener('click', function () {
                 dialog.hideDialog();
@@ -267,7 +267,7 @@ function initialize(changePanelVisibilityCallback) {
                 this.shadowRoot.appendChild(this.shadowRoot.querySelector('label'));
             }
 
-            if (this.hasAttribute('read-out')) {
+            if (this.hasAttribute('spoken')) {
                 this.shadowRoot.querySelector('label').setAttribute('aria-hidden', false);
             }
         },
@@ -322,7 +322,7 @@ function initialize(changePanelVisibilityCallback) {
             label.setAttribute('for', this.getAttribute('for'));
             this.setAttribute('for', '');
 
-            if (this.hasAttribute('read-out')) {
+            if (this.hasAttribute('spoken')) {
                 label.setAttribute('aria-hidden', 'false');
             }
         }
@@ -395,7 +395,7 @@ function initialize(changePanelVisibilityCallback) {
             this._internalValue = 0;
 
             var input = this.shadowRoot.querySelector('input');
-            var readLabel = this.getAttribute('read-label');
+            var readLabel = this.getAttribute('spoken-text');
             if (readLabel) {
                 input.setAttribute('aria-label', readLabel);
             } else {
@@ -464,8 +464,8 @@ function initialize(changePanelVisibilityCallback) {
         initialize: function () {
             var label = this.shadowRoot.querySelector('label');
             label.textContent = this.getAttribute('label');
-            var readLabelDiv = this.shadowRoot.querySelector('.read-label');
-            var readLabel = this.getAttribute('read-label');
+            var readLabelDiv = this.shadowRoot.querySelector('.spoken-text');
+            var readLabel = this.getAttribute('spoken-text');
             if (readLabel) {
                 readLabelDiv.setAttribute('aria-label', readLabel);
             } else {
@@ -487,7 +487,7 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            var readLabel = this.getAttribute('read-label');
+            var readLabel = this.getAttribute('spoken-text');
             if (readLabel) {
                 this.shadowRoot.querySelector('button').setAttribute('aria-label', readLabel);
             }

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -463,7 +463,7 @@ function initialize(changePanelVisibilityCallback) {
         },
         initialize: function () {
             this.shadowRoot.querySelector('label').textContent = this.getAttribute('label'); 
-            this.shadowRoot.querySelector('.cordova-value').textContent = this.getAttribute('value');
+            this.shadowRoot.querySelector('span').textContent = this.getAttribute('value');
             this.classList.add('cordova-panel-row');
             this.classList.add('cordova-group');
         }

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -53,8 +53,8 @@ function initialize(changePanelVisibilityCallback) {
             var panelId = this.getAttribute('id');
             var collapseIcon = this.shadowRoot.querySelector('.cordova-collapse-icon');
 
-            this.shadowRoot.querySelector('.cordova-header #panel-label span').textContent = this.getAttribute('caption');
-            this.shadowRoot.querySelector('.cordova-header #panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
+            this.shadowRoot.querySelector('.cordova-header .panel-label span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header .panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
             
             function expandCollapse() {
                 var collapsed = collapseIcon.classList.contains('cordova-collapsed');
@@ -102,8 +102,8 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            this.shadowRoot.querySelector('.cordova-header #panel-label span').textContent = this.getAttribute('caption');
-            this.shadowRoot.querySelector('.cordova-header #panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
+            this.shadowRoot.querySelector('.cordova-header .panel-label span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header .panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
 
             this.shadowRoot.querySelector('.cordova-close-icon').addEventListener('click', function () {
                 dialog.hideDialog();
@@ -266,8 +266,8 @@ function initialize(changePanelVisibilityCallback) {
                 // Reverse the order of the checkbox and caption
                 this.shadowRoot.appendChild(this.shadowRoot.querySelector('label'));
             }
-            var shouldReadOut = this.getAttribute('read-out');
-            if (shouldReadOut && shouldReadOut == 'true') {
+
+            if (this.hasAttribute('read-out')) {
                 this.shadowRoot.querySelector('label').setAttribute('aria-hidden', false);
             }
         },
@@ -321,8 +321,8 @@ function initialize(changePanelVisibilityCallback) {
             label.textContent = this.getAttribute('label');
             label.setAttribute('for', this.getAttribute('for'));
             this.setAttribute('for', '');
-            var shouldReadOut = this.getAttribute('read-out');
-            if (shouldReadOut && shouldReadOut == 'true') {
+
+            if (this.hasAttribute('read-out')) {
                 label.setAttribute('aria-hidden', 'false');
             }
         }

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -266,6 +266,10 @@ function initialize(changePanelVisibilityCallback) {
                 // Reverse the order of the checkbox and caption
                 this.shadowRoot.appendChild(this.shadowRoot.querySelector('label'));
             }
+            var shouldReadOut = this.getAttribute('read-out');
+            if (shouldReadOut && shouldReadOut == 'true') {
+                this.shadowRoot.querySelector('label').setAttribute('aria-hidden', false);
+            }
         },
         mungeIds: 'cordova-checkbox-template-input'
     });
@@ -465,9 +469,9 @@ function initialize(changePanelVisibilityCallback) {
             if (readLabel) {
                 readLabelDiv.setAttribute('aria-label', readLabel);
             } else {
-                readLabelDiv.setAttribute('aria-label', label);
+                readLabelDiv.setAttribute('aria-label', label.textContent);
             }
-            
+
             this.shadowRoot.querySelector('span').textContent = this.getAttribute('value');
             this.classList.add('cordova-panel-row');
             this.classList.add('cordova-group');

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -53,7 +53,7 @@ function initialize(changePanelVisibilityCallback) {
             var panelId = this.getAttribute('id');
             var collapseIcon = this.shadowRoot.querySelector('.cordova-collapse-icon');
 
-            this.shadowRoot.querySelector('.cordova-header span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header #panel-label span').textContent = this.getAttribute('caption');
             this.shadowRoot.querySelector('.cordova-header #panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
             
             function expandCollapse() {

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -53,8 +53,11 @@ function initialize(changePanelVisibilityCallback) {
             var panelId = this.getAttribute('id');
             var collapseIcon = this.shadowRoot.querySelector('.cordova-collapse-icon');
 
-            this.shadowRoot.querySelector('.cordova-header span').textContent = this.getAttribute('caption');
-
+            var caption = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header span').textContent = caption;
+            var panelLabel = this.shadowRoot.querySelector('.cordova-header #panel-label');
+            panelLabel.setAttribute('aria-label', caption + panelLabel.getAttribute('aria-label'));
+            
             function expandCollapse() {
                 var collapsed = collapseIcon.classList.contains('cordova-collapsed');
 

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -462,17 +462,8 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            var label = this.shadowRoot.querySelector('label');
-            label.textContent = this.getAttribute('label');
-            var readLabelDiv = this.shadowRoot.querySelector('.spoken-text');
-            var readLabel = this.getAttribute('spoken-text');
-            if (readLabel) {
-                readLabelDiv.setAttribute('aria-label', readLabel);
-            } else {
-                readLabelDiv.setAttribute('aria-label', label.textContent);
-            }
-
-            this.shadowRoot.querySelector('span').textContent = this.getAttribute('value');
+            this.shadowRoot.querySelector('label').textContent = this.getAttribute('label'); 
+            this.shadowRoot.querySelector('.cordova-value').textContent = this.getAttribute('value');
             this.classList.add('cordova-panel-row');
             this.classList.add('cordova-group');
         }

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -53,10 +53,8 @@ function initialize(changePanelVisibilityCallback) {
             var panelId = this.getAttribute('id');
             var collapseIcon = this.shadowRoot.querySelector('.cordova-collapse-icon');
 
-            var caption = this.getAttribute('caption');
-            this.shadowRoot.querySelector('.cordova-header span').textContent = caption;
-            var panelLabel = this.shadowRoot.querySelector('.cordova-header #panel-label');
-            panelLabel.setAttribute('aria-label', caption + panelLabel.getAttribute('aria-label'));
+            this.shadowRoot.querySelector('.cordova-header span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header #panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
             
             function expandCollapse() {
                 var collapsed = collapseIcon.classList.contains('cordova-collapsed');

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -458,7 +458,16 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');
+            var label = this.shadowRoot.querySelector('label');
+            label.textContent = this.getAttribute('label');
+            var readLabelDiv = this.shadowRoot.querySelector('.read-label');
+            var readLabel = this.getAttribute('read-label');
+            if (readLabel) {
+                readLabelDiv.setAttribute('aria-label', readLabel);
+            } else {
+                readLabelDiv.setAttribute('aria-label', label);
+            }
+            
             this.shadowRoot.querySelector('span').textContent = this.getAttribute('value');
             this.classList.add('cordova-panel-row');
             this.classList.add('cordova-group');

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -101,7 +101,9 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            this.shadowRoot.querySelector('.cordova-header span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header #panel-label span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header #panel-label').setAttribute('aria-label', this.getAttribute('panel-label'));
+
             this.shadowRoot.querySelector('.cordova-close-icon').addEventListener('click', function () {
                 dialog.hideDialog();
             });

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -91,6 +91,7 @@ function initialize(changePanelVisibilityCallback) {
                     if (focusElement) {
                         focusElement.focus();
                     }
+                    this.querySelector('.cordova-panel-inner').focus();
                 }
             },
             hide: {
@@ -312,9 +313,14 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');
-            this.shadowRoot.querySelector('label').setAttribute('for', this.getAttribute('for'));
+            var label = this.shadowRoot.querySelector('label');
+            label.textContent = this.getAttribute('label');
+            label.setAttribute('for', this.getAttribute('for'));
             this.setAttribute('for', '');
+            var shouldReadOut = this.getAttribute('read-out');
+            if (shouldReadOut && shouldReadOut == 'true') {
+                label.setAttribute('aria-hidden', 'false');
+            }
         }
     });
 
@@ -378,12 +384,19 @@ function initialize(changePanelVisibilityCallback) {
             }
         },
         initialize: function () {
-            this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');
+            var displayLabel = this.getAttribute('label');
+            this.shadowRoot.querySelector('label').textContent = displayLabel;
             this.classList.add('cordova-panel-row');
             this.classList.add('cordova-group');
             this._internalValue = 0;
 
             var input = this.shadowRoot.querySelector('input');
+            var readLabel = this.getAttribute('read-label');
+            if (readLabel) {
+                input.setAttribute('aria-label', readLabel);
+            } else {
+                input.setAttribute('aria-label', displayLabel);
+            }
 
             var maxValue = this.getAttribute('max'),
                 minValue = this.getAttribute('min'),
@@ -458,6 +471,12 @@ function initialize(changePanelVisibilityCallback) {
                 value: function () {
                     this.shadowRoot.querySelector('button').focus();
                 }
+            }
+        },
+        initialize: function () {
+            var readLabel = this.getAttribute('read-label');
+            if (readLabel) {
+                this.shadowRoot.querySelector('button').setAttribute('aria-label', readLabel);
             }
         },
         eventTarget: 'button'

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -81,7 +81,7 @@
     </template>
 
     <template id="cordova-labeled-value-template">
-        <div class="spoken-text"><label aria-hidden="true"></label></div>
+        <label></label>
         <span class="cordova-value"></span>
     </template>
 

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -16,7 +16,7 @@
          getting cropped in Chrome when wrapping columns -->
     <template id="cordova-panel-template">
         <section class="cordova-panel-inner" tabindex="0">
-            <section class="cordova-header"><span id="panel-label"><span aria-hidden="true"></span></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
+            <section class="cordova-header"><span class="panel-label"><span aria-hidden="true"></span></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <polyline class="cordova-collapse-up" points="2,11 7,6 12,11" stroke-width="1.5" ></polyline>
                 <polyline class="cordova-collapse-down" points="2,6 7,11 12,6" stroke-width="1.5"></polyline>
             </svg></span></section>
@@ -28,7 +28,7 @@
 
     <template id="cordova-dialog-template">
         <section class="cordova-panel-inner" tabindex="0">
-            <section class="cordova-header"><span id="panel-label"><span aria-hidden="true"></span></span><span class="cordova-close-icon"><svg focusable="false" viewBox="0 0 14 14">
+            <section class="cordova-header"><span class="panel-label"><span aria-hidden="true"></span></span><span class="cordova-close-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <line x1="2" y1="4" x2="11" y2="13" stroke-width="1.5"></line>
                 <line x1="11" y1="4" x2="2" y2="13" stroke-width="1.5"></line>
             </svg></span></section>

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -16,7 +16,7 @@
          getting cropped in Chrome when wrapping columns -->
     <template id="cordova-panel-template">
         <section class="cordova-panel-inner" tabindex="0">
-            <section class="cordova-header"><div id="panel-label" /><span aria-hidden="true"></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
+            <section class="cordova-header"><span id="panel-label"><span aria-hidden="true"></span></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <polyline class="cordova-collapse-up" points="2,11 7,6 12,11" stroke-width="1.5" ></polyline>
                 <polyline class="cordova-collapse-down" points="2,6 7,11 12,6" stroke-width="1.5"></polyline>
             </svg></span></section>
@@ -77,7 +77,7 @@
     </template>
 
     <template id="cordova-label-template">
-        <label></label>
+        <label aria-hidden="true"></label>
     </template>
 
     <template id="cordova-labeled-value-template">

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -16,7 +16,7 @@
          getting cropped in Chrome when wrapping columns -->
     <template id="cordova-panel-template">
         <section class="cordova-panel-inner" tabindex="0">
-            <section class="cordova-header"><span></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
+            <section class="cordova-header"><div id="panel-label" aria-label=" panel" /><span aria-hidden="true"></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <polyline class="cordova-collapse-up" points="2,11 7,6 12,11" stroke-width="1.5" ></polyline>
                 <polyline class="cordova-collapse-down" points="2,6 7,11 12,6" stroke-width="1.5"></polyline>
             </svg></span></section>
@@ -91,7 +91,7 @@
     </template>
 
     <template id="cordova-number-entry-template">
-        <label for="cordova-number-entry-template-input"></label>
+        <label aria-hidden="true" for="cordova-number-entry-template-input"></label>
         <input id="cordova-number-entry-template-input" type="number">
     </template>
 
@@ -106,7 +106,7 @@
     </template>
 
     <template id="cordova-combo-template">
-        <label for="cordova-combo-template-select"></label>
+        <label aria-hidden="true" for="cordova-combo-template-select"></label>
         <select id="cordova-combo-template-select"></select>
     </template>
 </head>

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -16,7 +16,7 @@
          getting cropped in Chrome when wrapping columns -->
     <template id="cordova-panel-template">
         <section class="cordova-panel-inner" tabindex="0">
-            <section class="cordova-header"><span class="panel-label"><span aria-hidden="true"></span></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
+            <section class="cordova-header"><span class="spoken-text"><span aria-hidden="true"></span></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <polyline class="cordova-collapse-up" points="2,11 7,6 12,11" stroke-width="1.5" ></polyline>
                 <polyline class="cordova-collapse-down" points="2,6 7,11 12,6" stroke-width="1.5"></polyline>
             </svg></span></section>
@@ -28,7 +28,7 @@
 
     <template id="cordova-dialog-template">
         <section class="cordova-panel-inner" tabindex="0">
-            <section class="cordova-header"><span class="panel-label"><span aria-hidden="true"></span></span><span class="cordova-close-icon"><svg focusable="false" viewBox="0 0 14 14">
+            <section class="cordova-header"><span class="spoken-text"><span aria-hidden="true"></span></span><span class="cordova-close-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <line x1="2" y1="4" x2="11" y2="13" stroke-width="1.5"></line>
                 <line x1="11" y1="4" x2="2" y2="13" stroke-width="1.5"></line>
             </svg></span></section>
@@ -81,7 +81,7 @@
     </template>
 
     <template id="cordova-labeled-value-template">
-        <div class="read-label"><label aria-hidden="true"></label></div>
+        <div class="spoken-text"><label aria-hidden="true"></label></div>
         <span class="cordova-value"></span>
     </template>
 

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -70,7 +70,7 @@
     </template>
 
     <template id="cordova-checkbox-template">
-        <label for="cordova-checkbox-template-input">
+        <label aria-hidden="true" for="cordova-checkbox-template-input">
             <content></content>
         </label>
         <input id="cordova-checkbox-template-input" type="checkbox">

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -27,8 +27,8 @@
     </template>
 
     <template id="cordova-dialog-template">
-        <section class="cordova-panel-inner">
-            <section class="cordova-header"><span></span><span class="cordova-close-icon"><svg focusable="false" viewBox="0 0 14 14">
+        <section class="cordova-panel-inner" tabindex="0">
+            <section class="cordova-header"><span id="panel-label"><span aria-hidden="true"></span></span><span class="cordova-close-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <line x1="2" y1="4" x2="11" y2="13" stroke-width="1.5"></line>
                 <line x1="11" y1="4" x2="2" y2="13" stroke-width="1.5"></line>
             </svg></span></section>

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -81,7 +81,7 @@
     </template>
 
     <template id="cordova-labeled-value-template">
-        <label></label>
+        <div class="read-label"><label aria-hidden="true"></label></div>
         <span class="cordova-value"></span>
     </template>
 

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -64,7 +64,7 @@
 
     <template id="cordova-radio-template">
         <input id="cordova-radio-template-input" type="radio">
-        <label for="cordova-radio-template-input" class="cordova-radio-label">
+        <label aria-hidden="true" for="cordova-radio-template-input" class="cordova-radio-label">
             <content></content>
         </label>
     </template>

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -16,7 +16,7 @@
          getting cropped in Chrome when wrapping columns -->
     <template id="cordova-panel-template">
         <section class="cordova-panel-inner" tabindex="0">
-            <section class="cordova-header"><div id="panel-label" aria-label=" panel" /><span aria-hidden="true"></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
+            <section class="cordova-header"><div id="panel-label" /><span aria-hidden="true"></span><span class="cordova-collapse-icon"><svg focusable="false" viewBox="0 0 14 14">
                 <polyline class="cordova-collapse-up" points="2,11 7,6 12,11" stroke-width="1.5" ></polyline>
                 <polyline class="cordova-collapse-down" points="2,6 7,11 12,6" stroke-width="1.5"></polyline>
             </svg></span></section>

--- a/tools/i18n/update.js
+++ b/tools/i18n/update.js
@@ -10,7 +10,7 @@ var fs = require('fs'),
     XMLSerializer = require('xmldom').XMLSerializer,
     translate = require('./translate');
 
-var translatedAttributes = ['label', 'caption'];
+var translatedAttributes = ['label', 'caption', 'panel-label'];
 var LOC_ID_ATTRIB = 'data-loc-id';
 var inlineTags = ['a', 'abbr', 'acronym', 'applet', 'b', 'bdo', 'big', 'blink', 'br', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'face', 'font', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'map', 'nobr', 'object', 'param', 'q', 'rb', 'rbc', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'select', 'small', 'spacer', 'span', 'strike', 'strong', 'sub', 'sup', 'symbol', 'textarea', 'tt', 'u', 'var', 'wbr'];
 var ignoreWords = [/\balpha\b/gi, /\bbeta\b/gi, /\bgamma\b/gi, /\bdeg\b/gi, /\bNE\b/gi, /\bNW\b/gi, /\bSE\b/gi, /\bSW\b/gi];

--- a/tools/i18n/update.js
+++ b/tools/i18n/update.js
@@ -10,7 +10,7 @@ var fs = require('fs'),
     XMLSerializer = require('xmldom').XMLSerializer,
     translate = require('./translate');
 
-var translatedAttributes = ['label', 'caption', 'panel-label', 'read-label'];
+var translatedAttributes = ['label', 'caption', 'spoken-text'];
 var LOC_ID_ATTRIB = 'data-loc-id';
 var inlineTags = ['a', 'abbr', 'acronym', 'applet', 'b', 'bdo', 'big', 'blink', 'br', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'face', 'font', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'map', 'nobr', 'object', 'param', 'q', 'rb', 'rbc', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'select', 'small', 'spacer', 'span', 'strike', 'strong', 'sub', 'sup', 'symbol', 'textarea', 'tt', 'u', 'var', 'wbr'];
 var ignoreWords = [/\balpha\b/gi, /\bbeta\b/gi, /\bgamma\b/gi, /\bdeg\b/gi, /\bNE\b/gi, /\bNW\b/gi, /\bSE\b/gi, /\bSW\b/gi];

--- a/tools/i18n/update.js
+++ b/tools/i18n/update.js
@@ -10,7 +10,7 @@ var fs = require('fs'),
     XMLSerializer = require('xmldom').XMLSerializer,
     translate = require('./translate');
 
-var translatedAttributes = ['label', 'caption', 'panel-label'];
+var translatedAttributes = ['label', 'caption', 'panel-label', 'read-label'];
 var LOC_ID_ATTRIB = 'data-loc-id';
 var inlineTags = ['a', 'abbr', 'acronym', 'applet', 'b', 'bdo', 'big', 'blink', 'br', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'face', 'font', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'map', 'nobr', 'object', 'param', 'q', 'rb', 'rbc', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'select', 'small', 'spacer', 'span', 'strike', 'strong', 'sub', 'sup', 'symbol', 'textarea', 'tt', 'u', 'var', 'wbr'];
 var ignoreWords = [/\balpha\b/gi, /\bbeta\b/gi, /\bgamma\b/gi, /\bdeg\b/gi, /\bNE\b/gi, /\bNW\b/gi, /\bSE\b/gi, /\bSW\b/gi];


### PR DESCRIPTION
1. For motion plugin - a) make sure text under image is not read out
2. For orientation plugin - a) make sure text under image is not read out b) make sure label for text box is not read twice when focus on the panel
3. For geolocation plugin - a) make sure geo-delay slider value is not read twice b) make sure the map is not read
4. In general, add "panel" to each panel caption when the caption is read out