### PR TITLE
Handle panel captions that are too wide to fit

### DIFF
--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -54,6 +54,7 @@ function initialize(changePanelVisibilityCallback) {
             var collapseIcon = this.shadowRoot.querySelector('.cordova-collapse-icon');
 
             this.shadowRoot.querySelector('.cordova-header .spoken-text span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header .spoken-text span').setAttribute('title', this.getAttribute('caption'));
             this.shadowRoot.querySelector('.cordova-header .spoken-text').setAttribute('aria-label', this.getAttribute('spoken-text') || this.getAttribute('caption'));
 
             function expandCollapse() {
@@ -97,6 +98,7 @@ function initialize(changePanelVisibilityCallback) {
         },
         initialize: function () {
             this.shadowRoot.querySelector('.cordova-header .spoken-text span').textContent = this.getAttribute('caption');
+            this.shadowRoot.querySelector('.cordova-header .spoken-text span').setAttribute('title', this.getAttribute('caption'));
             this.shadowRoot.querySelector('.cordova-header .spoken-text').setAttribute('aria-label', this.getAttribute('spoken-text') || this.getAttribute('caption'));
 
             this.shadowRoot.querySelector('.cordova-close-icon').addEventListener('click', function () {

--- a/src/sim-host/ui/sim-host-scaled.css
+++ b/src/sim-host/ui/sim-host-scaled.css
@@ -23,6 +23,10 @@ body /deep/ .cordova-header {
     line-height: 20px;
 }
 
+body /deep/ .cordova-header .spoken-text span {
+    width: calc(100% - 40px);
+}
+
 /* 12px margin around top level items in the content a panel */
 body /deep/ .cordova-content > ::content > * {
     margin: 12px;

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -55,10 +55,15 @@ body /deep/ .cordova-content > ::content > * {
     -webkit-column-gap: 0;
 }
 
-body /deep/ .cordova-value {
+body /deep/ .cordova-value,
+body /deep/ .cordova-header .spoken-text span {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+body /deep/ .cordova-header .spoken-text span {
+    position: absolute;
 }
 
 body /deep/ input {


### PR DESCRIPTION
* Typically because of localization
* Clip caption and show an ellipsis
* Provide a tooltip