### PR TITLE
Use CSS to scale compass, so it happens automatically

### DIFF
--- a/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host-panels.html
@@ -4,38 +4,42 @@
     <cordova-group>
         <cordova-panel-row>
             <div id="compass-widget">
-                <svg aria-hidden="true" focusable="false" width="100%" height="100%" viewBox="-2.5 -2.5 205 205" style="position: absolute;stroke:currentColor;fill:currentColor">
-                    <defs>
-                        <line id="radial-line" x1="100" y1="23" x2="100" y2="28" stroke-width="1" stroke-opacity="0.25"></line>
-                    </defs>
+                <div class="cordova-square-box-container">
+                    <div class="cordova-square-box-content">
+                        <svg aria-hidden="true" focusable="false" width="100%" height="100%" viewBox="-2.5 -2.5 205 205" style="position: absolute;stroke:currentColor;fill:currentColor">
+                            <defs>
+                                <line id="radial-line" x1="100" y1="23" x2="100" y2="28" stroke-width="1" stroke-opacity="0.25"></line>
+                            </defs>
 
-                    <circle r="75.5" cx="100" cy="100" fill-opacity="0" stroke-opacity="0.06" stroke-width="40"></circle>
-                    <line x1="100" x2="100" y1="9.5" y2="42.5" stroke="rgb(175,100,100)" stroke-width="3"></line>
+                            <circle r="75.5" cx="100" cy="100" fill-opacity="0" stroke-opacity="0.06" stroke-width="40"></circle>
+                            <line x1="100" x2="100" y1="9.5" y2="42.5" stroke="rgb(175,100,100)" stroke-width="3"></line>
 
-                    <g id="compass-face">
-                        <use xlink:href="#radial-line" transform="rotate(22.5,100,100)"></use>
-                        <use xlink:href="#radial-line" transform="rotate(67.5,100,100)"></use>
-                        <use xlink:href="#radial-line" transform="rotate(112.5,100,100)"></use>
-                        <use xlink:href="#radial-line" transform="rotate(157.5,100,100)"></use>
-                        <use xlink:href="#radial-line" transform="rotate(202.5,100,100)"></use>
-                        <use xlink:href="#radial-line" transform="rotate(247.5,100,100)"></use>
-                        <use xlink:href="#radial-line" transform="rotate(292.5,100,100)"></use>
-                        <use xlink:href="#radial-line" transform="rotate(337.5,100,100)"></use>
+                            <g id="compass-face">
+                                <use xlink:href="#radial-line" transform="rotate(22.5,100,100)"></use>
+                                <use xlink:href="#radial-line" transform="rotate(67.5,100,100)"></use>
+                                <use xlink:href="#radial-line" transform="rotate(112.5,100,100)"></use>
+                                <use xlink:href="#radial-line" transform="rotate(157.5,100,100)"></use>
+                                <use xlink:href="#radial-line" transform="rotate(202.5,100,100)"></use>
+                                <use xlink:href="#radial-line" transform="rotate(247.5,100,100)"></use>
+                                <use xlink:href="#radial-line" transform="rotate(292.5,100,100)"></use>
+                                <use xlink:href="#radial-line" transform="rotate(337.5,100,100)"></use>
 
-                        <text x="100" y="35" font-family="sans-serif" font-size="25" text-anchor="middle" fill-opacity="0.84" stroke-width="0">N</text>
-                        <text x="100" y="35" text-anchor="middle" font-family="sans-serif" font-size="25" fill-opacity="0.84" stroke-width="0" transform="rotate(-90,100,100)">W</text>
-                        <text x="100" y="35" text-anchor="middle" font-family="sans-serif" font-size="25" fill-opacity="0.84" stroke-width="0" transform="rotate(90,100,100)">E</text>
-                        <text x="100" y="35" text-anchor="middle" font-family="sans-serif" font-size="25" fill-opacity="0.84" stroke-width="0" transform="rotate(180,100,100)">S</text>
+                                <text x="100" y="35" font-family="sans-serif" font-size="25" text-anchor="middle" fill-opacity="0.84" stroke-width="0">N</text>
+                                <text x="100" y="35" text-anchor="middle" font-family="sans-serif" font-size="25" fill-opacity="0.84" stroke-width="0" transform="rotate(-90,100,100)">W</text>
+                                <text x="100" y="35" text-anchor="middle" font-family="sans-serif" font-size="25" fill-opacity="0.84" stroke-width="0" transform="rotate(90,100,100)">E</text>
+                                <text x="100" y="35" text-anchor="middle" font-family="sans-serif" font-size="25" fill-opacity="0.84" stroke-width="0" transform="rotate(180,100,100)">S</text>
 
-                        <text transform="rotate(45,100,100)" x="100" y="31" font-family="sans-serif" font-size="12" text-anchor="middle" fill-opacity="0.53" stroke-width="0">NE</text>
-                        <text transform="rotate(135,100,100)" x="100" y="31" font-family="sans-serif" font-size="12" text-anchor="middle" fill-opacity="0.53" stroke-width="0">SE</text>
-                        <text transform="rotate(225,100,100)" x="100" y="31" font-family="sans-serif" font-size="12" text-anchor="middle" fill-opacity="0.53" stroke-width="0">SW</text>
-                        <text transform="rotate(315,100,100)" x="100" y="31" font-family="sans-serif" font-size="12" text-anchor="middle" fill-opacity="0.53" stroke-width="0">NW</text>
-                    </g>
+                                <text transform="rotate(45,100,100)" x="100" y="31" font-family="sans-serif" font-size="12" text-anchor="middle" fill-opacity="0.53" stroke-width="0">NE</text>
+                                <text transform="rotate(135,100,100)" x="100" y="31" font-family="sans-serif" font-size="12" text-anchor="middle" fill-opacity="0.53" stroke-width="0">SE</text>
+                                <text transform="rotate(225,100,100)" x="100" y="31" font-family="sans-serif" font-size="12" text-anchor="middle" fill-opacity="0.53" stroke-width="0">SW</text>
+                                <text transform="rotate(315,100,100)" x="100" y="31" font-family="sans-serif" font-size="12" text-anchor="middle" fill-opacity="0.53" stroke-width="0">NW</text>
+                            </g>
 
-                    <circle r="49.5" cx="100" cy="100" stroke-opacity="0.37" fill-opacity="0" stroke-width="12"></circle>
-                    <circle r="95" cx="100" cy="100" stroke-opacity="0.37" fill-opacity="0" stroke-width="4"></circle>
-                </svg>
+                            <circle r="49.5" cx="100" cy="100" stroke-opacity="0.37" fill-opacity="0" stroke-width="12"></circle>
+                            <circle r="95" cx="100" cy="100" stroke-opacity="0.37" fill-opacity="0" stroke-width="4"></circle>
+                        </svg>
+                    </div>
+                </div>
             </div>
         </cordova-panel-row>
 

--- a/src/plugins/cordova-plugin-device-orientation/sim-host.css
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host.css
@@ -1,6 +1,9 @@
 #device-orientation #compass-widget {
     margin: 0 auto;
     position: relative;
+
+    /* Weird percentage is 184/294, which keeps size the same as it used to be */
+    width: 62.59%;
 }
 
 #device-orientation [data-compass-heading="text"] {

--- a/src/plugins/cordova-plugin-device-orientation/sim-host.js
+++ b/src/plugins/cordova-plugin-device-orientation/sim-host.js
@@ -24,15 +24,8 @@ module.exports = function (messages) {
         var inputHeading = document.getElementById('compass-heading-value'),
             headingText = document.querySelector('[data-compass-heading="text"]');
 
-        // Determine a scale to use for the compass. This treats a panel width of 320px as being "100%"
-        var scale = parseFloat(window.getComputedStyle(document.querySelector('cordova-panel')).width) / 320;
-        var container = document.querySelector('#device-orientation #compass-widget');
-        var containerSize = (184 * scale) + 'px';
-        container.style.width = containerSize;
-        container.style.height = containerSize;
-
         var compassWidget = new CompassWidget({
-            container: container,
+            container: document.querySelector('#device-orientation #compass-widget'),
             headingUpdatedCallback: function (heading) {
                 messages.emit('device-orientation-updated', heading.value, true);
             },

--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -219,6 +219,18 @@ body /deep/ .cordova-hidden {
     display: none;
 }
 
+body /deep/ .cordova-square-box-container {
+    position: relative;
+    width: 100%;
+    padding-bottom: 100%;
+}
+
+body /deep/ .cordova-square-box-content {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}
+
 body /deep/ input[type=range] {
     background: transparent;
     outline: none;


### PR DESCRIPTION
When theme is changed on the fly, the compass doesn't scale to the new font size because that calculation was made on page load. Use CSS to scale instead, so it scales automatically with the panel width.