### PR TITLE
Use CSS to scale accelerometer device, so it happens automatically

### DIFF
--- a/src/plugins/cordova-plugin-device-motion/sim-host.css
+++ b/src/plugins/cordova-plugin-device-motion/sim-host.css
@@ -6,8 +6,10 @@
     margin-right: auto;
 }
 
-#accelerometer-canvas {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
+#device-motion #accelerometer-canvas {
+    margin: 0 auto;
+    position: relative;
+
+    /* Weird percentage is 200/294, which keeps size the same as it used to be */
+    width: 68.03%;
 }

--- a/src/plugins/cordova-plugin-device-motion/sim-host.js
+++ b/src/plugins/cordova-plugin-device-motion/sim-host.js
@@ -91,14 +91,6 @@ function initialize() {
         if (axis.hasOwnProperty('gamma')) gamma.value = axis.gamma;
     });
 
-    // Determine a scale to use for the compass. This treats a panel width of 320px as being '100%'
-    var scale = parseFloat(window.getComputedStyle(document.querySelector('cordova-panel')).width) / 320;
-    var canvasElement = document.getElementById('accelerometer-canvas');
-    var canvas = canvasElement.getContext('2d');
-    canvasElement.setAttribute('width', Math.round(scale * 200));
-    canvasElement.setAttribute('height', Math.round(scale * 160));
-    canvas.scale(scale, scale);
-
     createCanvas();
 
     setToDefaultPosition();


### PR DESCRIPTION
When theme is changed on the fly, the accelerometer device widget doesn't scale to the new font size because that calculation was made on page load. Use CSS to scale instead, so it scales automatically with the panel width.