### PR TITLE
Add support for scrollbar colors to themes.

### DIFF
--- a/src/server/theme.js
+++ b/src/server/theme.js
@@ -164,6 +164,11 @@ Theme.prototype._createThemeCssFile = function (themeCssFileName) {
         });
     });
 
+    // Allow the sim host to do any custom stuff that couldn't be handled with the default selector handling
+    if (this._simHostThemeInfo.doCustom) {
+        this._simHostThemeInfo.doCustom(css, themeObject)
+    }
+
     // If sim host provides a CSS file to be scaled, scale and append it. Scaling searches for sizes declared in pixels,
     // and scales them based on the current font size compared to the sim-host's default font size (always rounded to a
     // whole pixel). This works better than, say, em sizing, which results in fractional pixel sizes and inconsistent

--- a/src/sim-host/ui/theme.js
+++ b/src/sim-host/ui/theme.js
@@ -85,5 +85,34 @@ module.exports = {
         }
     },
 
-    defaultFontSize: 13
+    defaultFontSize: 13,
+
+    doCustom: function (css, themeObject) {
+        // Support scroll bar colors. Note that this is only supported for IE, because Webkit/Chrome makes it too difficult.
+        var scrollBarColors = themeObject.scrollbar && themeObject.scrollbar[''];
+        if (scrollBarColors) {
+            var ieScrollBarColorCssProperties = [];
+            if (scrollBarColors.arrow) {
+                ieScrollBarColorCssProperties.push('  scrollbar-arrow-color: ' + scrollBarColors.arrow + ';');
+            }
+
+            if (scrollBarColors.face) {
+                ieScrollBarColorCssProperties.push('  scrollbar-face-color: ' + scrollBarColors.face + ';');
+            }
+
+            if (scrollBarColors.background) {
+                ieScrollBarColorCssProperties.push('  scrollbar-3dlight-color: ' + scrollBarColors.background + ';');
+                ieScrollBarColorCssProperties.push('  scrollbar-darkshadow-color: ' + scrollBarColors.background + ';');
+                ieScrollBarColorCssProperties.push('  scrollbar-highlight-color: ' + scrollBarColors.background + ';');
+                ieScrollBarColorCssProperties.push('  scrollbar-shadow-color: ' + scrollBarColors.background + ';');
+                ieScrollBarColorCssProperties.push('  scrollbar-track-color: ' + scrollBarColors.background + ';');
+            }
+
+            if (ieScrollBarColorCssProperties.length) {
+                css.push('body {');
+                css.push(ieScrollBarColorCssProperties.join('\n'));
+                css.push('}');
+            }
+        }
+    }
 };


### PR DESCRIPTION
Note that this currently only works for IE. With Chrome, if you theme the scrollbars you lose the arrows. You can add them back in manually (via a background image), but that's not something I'm going to do right now.