### PR TITLE
Add 'name' property to GPX playback speed combobox.

### DIFF
--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -60,7 +60,7 @@
         </section>
         <section>
             <cordova-button id="geo-gpx-go" style="min-width:0;" data-loc-id="323b1c35">Go</cordova-button>
-            <cordova-combo id="geo-gpxmultiplier-select" style="width:auto;min-width:0;display:inline;">
+            <cordova-combo name="GPX playback speed" id="geo-gpxmultiplier-select" style="width:auto;min-width:0;display:inline;" data-loc-id="11d32900">
                 <option value="1">1x</option>
                 <option value="2">2x</option>
                 <option value="4">4x</option>

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -535,6 +535,12 @@ function initialize(changePanelVisibilityCallback) {
             this.classList.add('cordova-panel-row');
             this.classList.add('cordova-group');
             var select = this.shadowRoot.querySelector('select');
+
+            var name = this.getAttribute('name');
+            if (name) {
+                select.setAttribute('name', name);
+            }
+
             var label = this.getAttribute('label');
             if (label) {
                 this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');

--- a/tools/i18n/update.js
+++ b/tools/i18n/update.js
@@ -10,7 +10,7 @@ var fs = require('fs'),
     XMLSerializer = require('xmldom').XMLSerializer,
     translate = require('./translate');
 
-var translatedAttributes = ['label', 'caption', 'spoken-text', 'aria-label'];
+var translatedAttributes = ['label', 'caption', 'spoken-text', 'aria-label', 'name'];
 var LOC_ID_ATTRIB = 'data-loc-id';
 var inlineTags = ['a', 'abbr', 'acronym', 'applet', 'b', 'bdo', 'big', 'blink', 'br', 'cite', 'code', 'del', 'dfn', 'em', 'embed', 'face', 'font', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'map', 'nobr', 'object', 'param', 'q', 'rb', 'rbc', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'select', 'small', 'spacer', 'span', 'strike', 'strong', 'sub', 'sup', 'symbol', 'textarea', 'tt', 'u', 'var', 'wbr'];
 var ignoreWords = [/\balpha\b/gi, /\bbeta\b/gi, /\bgamma\b/gi, /\bdeg\b/gi, /\bNE\b/gi, /\bNW\b/gi, /\bSE\b/gi, /\bSW\b/gi];


### PR DESCRIPTION
Also, update `cordova-combobox` to handle `name` property, and localization tools to treat name property as translatable.