### PR TITLE
Fixed bug 385093: Accessibility: MAS42A: HC: Text on "Fire event,Choose file,Go button and Zoom in and Zoom out"  buttons in cordova simulation window is not according to the HighContrast Mode

### DIFF
--- a/src/sim-host/ui/sim-host.css
+++ b/src/sim-host/ui/sim-host.css
@@ -264,6 +264,21 @@ body /deep/ input[type=range]::-webkit-slider-thumb {
     -webkit-appearance: none;
 }
 
+/* Use correct colors for buttons in IE in high-contrast mode */
+@media screen and (-ms-high-contrast: active) {
+    button {
+        color: buttonText;
+        border-color: buttonText;
+        background-color: buttonFace;
+    }
+
+    button:hover, button:focus {
+        color: highlightText;
+        border-color: buttonText;
+        background-color: highlight;
+    }
+}
+
 /* Hacks to work around multi-column bug in Chrome 48+. The following section
    is removed for other browsers when the file is served */
 

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -12,6 +12,22 @@
     <script src="/simulator/thirdparty/socket.io.js"></script>
     <script src="sim-host.js"></script>
 
+    <style>
+        @media screen and (-ms-high-contrast: white-on-black) {
+            button:hover {
+                border-color: cyan;
+                color: cyan;
+            }
+        }
+
+        @media screen and (-ms-high-contrast: black-on-white) {
+            button:hover {
+                border-color: darkmagenta;
+                color: darkmagenta;
+            }
+        }
+    </style>
+
     <!-- For cordova-panel and cordova-dialog, the shadow is applied to the inner section, in order to prevent it
          getting cropped in Chrome when wrapping columns -->
     <template id="cordova-panel-template">

--- a/src/sim-host/ui/sim-host.html
+++ b/src/sim-host/ui/sim-host.html
@@ -12,22 +12,6 @@
     <script src="/simulator/thirdparty/socket.io.js"></script>
     <script src="sim-host.js"></script>
 
-    <style>
-        @media screen and (-ms-high-contrast: white-on-black) {
-            button:hover {
-                border-color: cyan;
-                color: cyan;
-            }
-        }
-
-        @media screen and (-ms-high-contrast: black-on-white) {
-            button:hover {
-                border-color: darkmagenta;
-                color: darkmagenta;
-            }
-        }
-    </style>
-
     <!-- For cordova-panel and cordova-dialog, the shadow is applied to the inner section, in order to prevent it
          getting cropped in Chrome when wrapping columns -->
     <template id="cordova-panel-template">


### PR DESCRIPTION
In case of using Windows high contrast theme Cordova buttons have the same color scheme as for standard Windows buttons. Please take a look at following examples: 
1. Windows black high contrast theme:
Windows buttons
![image](https://cloud.githubusercontent.com/assets/27480105/25699492/25e29900-30cc-11e7-9562-f2c42798c8eb.png)
and Cordova buttons
![image](https://cloud.githubusercontent.com/assets/27480105/25699504/35dece50-30cc-11e7-826c-23ef1ec0ed20.png)
2. Windows black high contrast theme:
Windows buttons
![image](https://cloud.githubusercontent.com/assets/27480105/25699535/57af74c6-30cc-11e7-905f-21859d4f99b6.png)
and Cordova buttons
![image](https://cloud.githubusercontent.com/assets/27480105/25699557/6ef738da-30cc-11e7-917d-e871d7663288.png)