### PR TITLE
Fix bug 433383: An exception is thrown when the header tag is added

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -252,7 +252,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
             send(request, filePath, {
                 transform: function (stream) {
                     return stream
-                        .pipe(replaceStream(/(<\s*head[\s]*>)/, '$1' + scriptTags))
+                        .pipe(replaceStream(/(<\s*head\b[^>]*>)/, '$1' + scriptTags))
                         .pipe(replaceStream(metaTagRegex, function (metaTag) {
                             if (!cspRegex.test(metaTag)) {
                                 // Not a CSP tag; return unchanged

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -252,7 +252,7 @@ SimulationServer.prototype._streamAppHostHtml = function (request, response) {
             send(request, filePath, {
                 transform: function (stream) {
                     return stream
-                        .pipe(replaceStream(/(<\s*head[^>]*>)/, '$1' + scriptTags))
+                        .pipe(replaceStream(/(<\s*head[\s]*>)/, '$1' + scriptTags))
                         .pipe(replaceStream(metaTagRegex, function (metaTag) {
                             if (!cspRegex.test(metaTag)) {
                                 // Not a CSP tag; return unchanged


### PR DESCRIPTION
Inject script to 'head' tag only.
Previously, there was an injection to all tags that begin from 'head' (etc. 'header', 'headblablabla').