### PR TITLE
Fix issue 126: Unhandled Exec Call dialog does not specify call arguments

### DIFF
--- a/src/plugins/exec/sim-host-dialogs.html
+++ b/src/plugins/exec/sim-host-dialogs.html
@@ -3,7 +3,7 @@
 <cordova-dialog id="exec-dialog" caption="Unhandled Exec Call" data-loc-id="f7283850">
     <cordova-group>
         <p data-loc-id="a1a63f26">There is no handler for the following exec call:</p>
-        <p style="font-style:italic"><span id="exec-service" data-loc-id="ba2b4c80">service</span>.<span id="exec-action" data-loc-id="e4c1ba28">action</span></p>
+        <p style="font-style:italic"><span id="exec-service" data-loc-id="ba2b4c80">service</span>.<span id="exec-action" data-loc-id="e4c1ba28">action</span>(<span id="exec-args" data-loc-id="e4c1ba29">args</span>)</p>
         <p data-loc-id="54b83b14">Please enter a value below to be returned for this call, then indicate whether this represents success or failure. If you wish to always respond to this call with this result, select the 'persist' option.</p>
     </cordova-group>
     <cordova-group>

--- a/src/plugins/exec/sim-host-handlers.js
+++ b/src/plugins/exec/sim-host-handlers.js
@@ -35,6 +35,7 @@ module.exports = {
                     errorDisplay.style.display = 'none';
                     document.getElementById('exec-service').textContent = service;
                     document.getElementById('exec-action').textContent = action;
+                    document.getElementById('exec-args').textContent = args;
 
                     /*eslint-disable no-inner-declarations */
                     function handleSuccess() {


### PR DESCRIPTION
Args show in () after action name now