### PR TITLE
Use new version of Microsoft text translation engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-eslint": "^2.0.0",
     "gulp-jsonlint": "^1.1.2",
     "in-publish": "^2.0.0",
-    "mstranslator": "^2.0.8",
+    "mstranslator": "^2.1.2",
     "parse5": "^2.2.1",
     "pretty-data": "^0.40.0",
     "xmldom": "^0.1.22"

--- a/tools/i18n/translate.js
+++ b/tools/i18n/translate.js
@@ -3,14 +3,12 @@
 var chalk = require('chalk');
 var MsTranslator = require('mstranslator');
 
-var clientId = process.env['CORDOVA-SIMULATE-TRANSLATE-CLIENT-ID'];
-var clientSecret = process.env['CORDOVA-SIMULATE-TRANSLATE-CLIENT-SECRET'];
+var apiKey = process.env['CORDOVA-SIMULATE-TRANSLATE-API-KEY'];
 var translateArray;
 
-if (clientId && clientSecret) {
+if (apiKey) {
     var translatorClient = new MsTranslator({
-        client_id: clientId,
-        client_secret: clientSecret
+        api_key: apiKey
     }, true);
 
     translateArray = function (texts, targetLanguage) {
@@ -33,11 +31,9 @@ if (clientId && clientSecret) {
         });
     }
 } else {
-    console.log(chalk.yellow.bold('Warning: Machine assisted translation is not enabled. To enable it, you need an account\n' +
-        'and app registered with the Azure DataMarket, with Microsoft Translator Text Translation\n' +
-        'support active, then set the following environment variables:\n' +
-        'CORDOVA-SIMULATE-TRANSLATE-CLIENT-ID: Azure DataMarket application Client ID.\n' +
-        'CORDOVA-SIMULATE-TRANSLATE-CLIENT-SECRET: Azure DataMarket application Client Secret.'));
+    console.log(chalk.yellow.bold('Warning: Machine assisted translation is not enabled. To enable it, you need an Azure\n' +
+        'account with Text Translation support active, then set the following environment variable:\n' +
+        'CORDOVA-SIMULATE-TRANSLATE-API-KEY: Azure Text Translation key.'));
 
     translateArray = function (texts) {
         return Promise.resolve(texts.map(function (text) {


### PR DESCRIPTION
Microsoft Translator is no longer available on the Microsoft DataMarket platform, since that was retired 4/30/2017. Now must access it via Azure portal. This change updates mstranslator npm module to the latest version, and passes an Azure portal key instead of Microsoft DataMarket client id and secret.