### PR TITLE
Fixes accessibility of the Geolocation plugin in Internet Explorer 11

### DIFF
--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -60,7 +60,7 @@
         </section>
         <section>
             <cordova-button id="geo-gpx-go" style="min-width:0;" data-loc-id="323b1c35">Go</cordova-button>
-            <cordova-combo name="GPX playback speed" id="geo-gpxmultiplier-select" style="width:auto;min-width:0;display:inline;" data-loc-id="11d32900">
+            <cordova-combo name="GPX playback speed" spoken-text="Playback speed multiplier" id="geo-gpxmultiplier-select" style="width:auto;min-width:0;display:inline;" data-loc-id="11d32900">
                 <option value="1">1x</option>
                 <option value="2">2x</option>
                 <option value="4">4x</option>

--- a/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-geolocation/sim-host-panels.html
@@ -55,12 +55,12 @@
     </cordova-panel-row>
     <cordova-panel-row>
         <section>
-            <cordova-button id="geo-gpxfile-button" style="width:100%" data-loc-id="f6c1471b">Choose File</cordova-button>
+            <cordova-button id="geo-gpxfile-button" spoken-text="Navigation Simulator - Choose File" style="width:100%" data-loc-id="f6c1471b">Choose File</cordova-button>
             <cordova-file hidden="true" id="geo-gpxfile"></cordova-file>
         </section>
         <section>
-            <cordova-button id="geo-gpx-go" style="min-width:0;" data-loc-id="323b1c35">Go</cordova-button>
-            <cordova-combo name="GPX playback speed" spoken-text="Playback speed multiplier" id="geo-gpxmultiplier-select" style="width:auto;min-width:0;display:inline;" data-loc-id="11d32900">
+            <cordova-button id="geo-gpx-go" spoken-text="Navigation Simulator - Go" style="min-width:0;" data-loc-id="323b1c35">Go</cordova-button>
+            <cordova-combo spoken-text="Navigation Simulator - playback speed multiplier" id="geo-gpxmultiplier-select" style="width:auto;min-width:0;display:inline;" data-loc-id="11d32900">
                 <option value="1">1x</option>
                 <option value="2">2x</option>
                 <option value="4">4x</option>

--- a/src/plugins/cordova-plugin-geolocation/sim-host.js
+++ b/src/plugins/cordova-plugin-geolocation/sim-host.js
@@ -487,6 +487,13 @@ module.exports = function (messages) {
                 }
             });
 
+            var navSimulationLabel = document.querySelector('[data-loc-id="f89bb5e3"]');
+            var navSimulationTitle = navSimulationLabel && navSimulationLabel.value;
+            if (navSimulationTitle) {
+                gpxFileButton.spoken = [navSimulationTitle, gpxFileButton.textContent].join(' ');
+                gpxGo.spoken = [navSimulationTitle, gpxGo.textContent].join(' ');
+            }
+
             gpxGo.addEventListener('click', function () {
                 replayGpxTrack();
             });

--- a/src/plugins/cordova-plugin-geolocation/sim-host.js
+++ b/src/plugins/cordova-plugin-geolocation/sim-host.js
@@ -487,9 +487,6 @@ module.exports = function (messages) {
                 }
             });
 
-            gpxFileButton.spoken = gpxFileButton.getAttribute('spoken-text')
-            gpxGo.spoken = gpxGo.getAttribute('spoken-text')
-
             gpxGo.addEventListener('click', function () {
                 replayGpxTrack();
             });

--- a/src/plugins/cordova-plugin-geolocation/sim-host.js
+++ b/src/plugins/cordova-plugin-geolocation/sim-host.js
@@ -487,12 +487,8 @@ module.exports = function (messages) {
                 }
             });
 
-            var navSimulationLabel = document.querySelector('[data-loc-id="f89bb5e3"]');
-            var navSimulationTitle = navSimulationLabel && navSimulationLabel.value;
-            if (navSimulationTitle) {
-                gpxFileButton.spoken = [navSimulationTitle, gpxFileButton.textContent].join(' ');
-                gpxGo.spoken = [navSimulationTitle, gpxGo.textContent].join(' ');
-            }
+            gpxFileButton.spoken = gpxFileButton.getAttribute('spoken-text')
+            gpxGo.spoken = gpxGo.getAttribute('spoken-text')
 
             gpxGo.addEventListener('click', function () {
                 replayGpxTrack();

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -468,6 +468,14 @@ function initialize(changePanelVisibilityCallback) {
                 value: function () {
                     this.shadowRoot.querySelector('button').focus();
                 }
+            },
+            spoken: {
+                set: function (value) {
+                    this.shadowRoot.querySelector('button').setAttribute('aria-label', value);
+                },
+                get: function () {
+                    return this.shadowRoot.querySelector('button').getAttribute('aria-label');
+                }
             }
         },
         initialize: function () {
@@ -543,11 +551,17 @@ function initialize(changePanelVisibilityCallback) {
 
             var label = this.getAttribute('label');
             if (label) {
-                this.shadowRoot.querySelector('label').textContent = this.getAttribute('label');
+                this.shadowRoot.querySelector('label').textContent = label;
             } else {
                 select.style.width = this.style.width || '100%';
                 select.style.minWidth = this.style.minWidth;
             }
+
+            var spokenText = this.getAttribute('spoken-text');
+            if (spokenText) {
+                select.setAttribute('aria-label', spokenText);
+            }
+
             // Move option elements to be children of select element
             var options = this.querySelectorAll('option');
             Array.prototype.forEach.call(options, function (option) {

--- a/src/sim-host/ui/custom-elements.js
+++ b/src/sim-host/ui/custom-elements.js
@@ -468,14 +468,6 @@ function initialize(changePanelVisibilityCallback) {
                 value: function () {
                     this.shadowRoot.querySelector('button').focus();
                 }
-            },
-            spoken: {
-                set: function (value) {
-                    this.shadowRoot.querySelector('button').setAttribute('aria-label', value);
-                },
-                get: function () {
-                    return this.shadowRoot.querySelector('button').getAttribute('aria-label');
-                }
             }
         },
         initialize: function () {
@@ -556,10 +548,10 @@ function initialize(changePanelVisibilityCallback) {
                 select.style.width = this.style.width || '100%';
                 select.style.minWidth = this.style.minWidth;
             }
-
-            var spokenText = this.getAttribute('spoken-text');
-            if (spokenText) {
-                select.setAttribute('aria-label', spokenText);
+            
+            var readLabel = this.getAttribute('spoken-text');
+            if (readLabel) {
+                select.setAttribute('aria-label', readLabel);
             }
 
             // Move option elements to be children of select element


### PR DESCRIPTION
Wrong read the labels adjacent to the "Go" button, when you use MS Narrator and the opening of `sim-host` in Internet Explorer 11 (Visual Studio 2017) 