### PR TITLE
Fixes getting mac os homedir

### DIFF
--- a/src/server/utils/jsUtils.js
+++ b/src/server/utils/jsUtils.js
@@ -160,7 +160,7 @@ function getAppDataPath() {
             break;
 
         case 'darwin':
-            appDataPath = process.env.HOMEPATH;
+            appDataPath = process.env.HOMEPATH || process.env.HOME;
             appDataPath = appDataPath && path.join(appDataPath, 'Library', 'Application Support');
             break;
 


### PR DESCRIPTION
This PR fixes an issue reported to us by one of the `vscode-cordova` extension users. See [here](https://github.com/Microsoft/vscode-cordova/issues/368#issuecomment-367417553). 
The homedir was not being retrieved properly on `darwin` platforms.