### PR TITLE
Handles the absence of reference attribute

### DIFF
--- a/src/app-host/live-reload-client.js
+++ b/src/app-host/live-reload-client.js
@@ -86,7 +86,7 @@ module.exports.start = function (sock) {
             var nodeReference = currentNode.getAttribute(referenceAttribute);
 
             // If the node's url / href / src doesn't reference the modified file on the server, ignore the node.
-            if (!urlMatchesPath(url.parse(nodeReference).pathname, fileRelativePath)) {
+            if (!nodeReference || !urlMatchesPath(url.parse(nodeReference).pathname, fileRelativePath)) {
                 continue;
             }
 


### PR DESCRIPTION
Actually, if `getReferenceAttributeForNode(currentNode)` returns null, `url.parse` is still called and it returns an error. 
This modification takes this case into account and avoids an error.