### PR TITLE
Disable crypto polyfill in browserify to remove vulnerable elliptic dependency

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,7 @@
 # cordova-simulate Release Notes
+## 1.3.3 (January 2026)
+* Security fix: Disabled crypto polyfill in browserify to remove transitive dependency on vulnerable 'elliptic' package (CVE-2025-14505) [#xxx](https://github.com/microsoft/cordova-simulate/pull/xxx
+
 ## 1.3.2 (June 26, 2024)
 * Internal Changes:
   * Bump express from 4.18.2 to 4.19.2 [#473](https://github.com/microsoft/cordova-simulate/pull/473)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-simulate",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-simulate",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-simulate",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Simulates your Cordova application in the browser.",
   "main": "src/simulate.js",
   "bin": {

--- a/src/server/sim-files.js
+++ b/src/server/sim-files.js
@@ -5,14 +5,34 @@ var browserify = require('browserify'),
     path = require('path'),
     through = require('through2'),
     dirs = require('./dirs'),
+    builtins = require('browserify/lib/builtins'),
     jsUtils = require('./utils/jsUtils'),
     log = require('./utils/log'),
     pluginSimulationFiles = require('./plugin-files');
 
 var _browserifySearchPaths = null,
     _commonModules = null,
+    _safeBuiltins = null,
     simHost = 'sim-host',
     appHost = 'app-host';
+
+/**
+ * Get browserify builtins with crypto-related modules disabled.
+ * This removes the transitive dependency on 'elliptic' package which has
+ * unpatched security vulnerabilities (CVE-2025-14505).
+ * cordova-simulate does not use crypto functionality in browser bundles.
+ * @return {object}
+ */
+function getSafeBuiltins() {
+    if (!_safeBuiltins) {
+        _safeBuiltins = Object.assign({}, builtins);
+        // Disable crypto-related polyfills to avoid elliptic dependency
+        // These modules pull in crypto-browserify -> browserify-sign -> elliptic
+        delete _safeBuiltins.crypto;
+        delete _safeBuiltins._crypto;
+    }
+    return _safeBuiltins;
+}
 
 /**
  * SimulationFiles handle the creation of sim-host and app-host files required
@@ -142,7 +162,8 @@ SimulationFiles.prototype._createHostJsFile = function (simulationFilePath, host
         paths: getBrowserifySearchPaths(hostType),
         debug: true,
         exports: false, // needed to prevent browserify to override hasExports option by set it to true
-        hasExports: false
+        hasExports: false,
+        builtins: getSafeBuiltins()
     });
 
     b.transform(function (file) {
@@ -280,5 +301,8 @@ function getCommonModules(hostType) {
     }
     return hostType ? _commonModules[hostType] : _commonModules;
 }
+
+// Export internal function for testing
+SimulationFiles._getSafeBuiltins = getSafeBuiltins;
 
 module.exports = SimulationFiles;


### PR DESCRIPTION
## Description

This PR addresses a security vulnerability by removing the transitive dependency on the `elliptic` package (CVE-2025-14505).

## Changes

- Modified `src/server/simulation-files.js` to disable `crypto` and `_crypto` builtins in browserify configuration
- Bumped version to 1.3.3

## Why This Works

The `elliptic` package is pulled in through:
```
browserify → crypto-browserify → browserify-sign/create-ecdh → elliptic
```

By disabling the crypto polyfill, browserify no longer bundles these modules, effectively removing elliptic from the output bundles.

## Testing

- [x] Ran `npm test` - all tests pass
- [x] Verified simulation functionality works without crypto polyfill
- [x] Confirmed elliptic is not included in output bundles

## Notes

The `elliptic` package will still appear in `npm ls elliptic` as it remains an installed dependency of browserify. However, it will not be included in any bundled output, eliminating the security risk.