### PR TITLE
Implement upstream proxy support in xhr_proxy.js

### DIFF
--- a/src/server/xhr-proxy.js
+++ b/src/server/xhr-proxy.js
@@ -6,6 +6,9 @@ var http = require('http'),
 
 module.exports.attach = function (app) {
     app.all('/xhr_proxy', function proxyXHR(request, response) {
+        // set upstream proxy based on environment if required
+        http.setGlobalProxyFromEnv()
+        
         var requestURL = url.parse(unescape(request.query.rurl));
 
         request.headers.host = requestURL.host;

--- a/src/server/xhr-proxy.js
+++ b/src/server/xhr-proxy.js
@@ -7,7 +7,7 @@ var http = require('http'),
 module.exports.attach = function (app) {
     app.all('/xhr_proxy', function proxyXHR(request, response) {
         // set upstream proxy based on environment if required
-        http.setGlobalProxyFromEnv()
+        http.setGlobalProxyFromEnv();
         
         var requestURL = url.parse(unescape(request.query.rurl));
 


### PR DESCRIPTION
This PR implements upstream proxy support in `xhr_proxy.js`, allowing simulated cordova applications to be routed via an HTTP proxy for debugging and analysis. 

Closes issue #586 