### PR TITLE
Bump ws to 8.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8010,9 +8010,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -10040,7 +10040,7 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.20.1"
+        "ws": "^8.21.0"
       },
       "dependencies": {
         "debug": {
@@ -13345,7 +13345,7 @@
       "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
       "requires": {
         "debug": "~4.4.1",
-        "ws": "~8.20.1"
+        "ws": "^8.21.0"
       },
       "dependencies": {
         "debug": {
@@ -14134,9 +14134,9 @@
       }
     },
     "ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "requires": {}
     },
     "xml": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   "overrides": {
     "flatted": "^3.4.2",
     "serialize-javascript": "^7.0.5",
-    "tmp": "^0.2.6"
+    "tmp": "^0.2.6",
+    "ws": "^8.21.0"
   },
   "scripts": {
     "update-loc": "node ./tools/i18n/update",


### PR DESCRIPTION
## Dependency Update

### What changed
- Added an npm \overrides\ entry forcing \ws\ to \^8.21.0\ (previously resolved transitively to 8.20.1).
- Regenerated \package-lock.json\ accordingly.

### Why
Updates the transitive \ws\ dependency to the latest 8.x patch release.

### Testing
- [ ] Lockfile regenerated; \ws\ resolves to 8.21.0
- [ ] No breaking API changes (transitive bump within same major)
