### PR TITLE
enforce network isolation and block public package sources

### DIFF
--- a/.ci/common-validation.yml
+++ b/.ci/common-validation.yml
@@ -28,7 +28,11 @@ steps:
 
         npm config set registry "${{ parameters.npmRegistry }}"
         npm config set always-auth true
+        npm config set replace-registry-host always
         echo "Using npm registry: $(npm config get registry)"
+
+        # Fail fast with a clearer error when the isolated registry is unreachable.
+        npm ping --registry "${{ parameters.npmRegistry }}"
       fi
     displayName: "Configure isolated npm registry"
   - bash: |
@@ -40,7 +44,17 @@ steps:
         fi
       fi
     displayName: "Block public package sources"
-  - bash: npm ci
+  - bash: |
+      set -euo pipefail
+      if [ "${{ parameters.enforceNetworkIsolation }}" = "true" ]; then
+        npm ci \
+          --registry "${{ parameters.npmRegistry }}" \
+          --fetch-retries 5 \
+          --fetch-retry-mintimeout 20000 \
+          --fetch-retry-maxtimeout 120000
+      else
+        npm ci
+      fi
     displayName: "npm ci"
   - bash: npx gulp
     displayName: "gulp default"

--- a/.ci/common-validation.yml
+++ b/.ci/common-validation.yml
@@ -1,13 +1,48 @@
+parameters:
+  - name: npmRegistry
+    type: string
+    default: ""
+  - name: enforceNetworkIsolation
+    type: boolean
+    default: true
+
 steps:
   - task: NodeTool@0
     displayName: "Use Node 18.x"
     inputs:
       versionSpec: 18.x
-  - bash: npm install gulp -g --force
-    displayName: "npm install gulp -g"
+  - bash: |
+      set -euo pipefail
+      if [ "${{ parameters.enforceNetworkIsolation }}" = "true" ]; then
+        if [ -z "${{ parameters.npmRegistry }}" ]; then
+          echo "NPM registry is required for network isolation. Set pipeline variable NPM_REGISTRY_URL."
+          exit 1
+        fi
+
+        case "${{ parameters.npmRegistry }}" in
+          *registry.npmjs.org*|*npmjs.org*)
+            echo "Public npm registry is not allowed for network-isolated builds: ${{ parameters.npmRegistry }}"
+            exit 1
+            ;;
+        esac
+
+        npm config set registry "${{ parameters.npmRegistry }}"
+        npm config set always-auth true
+        echo "Using npm registry: $(npm config get registry)"
+      fi
+    displayName: "Configure isolated npm registry"
+  - bash: |
+      set -euo pipefail
+      if [ "${{ parameters.enforceNetworkIsolation }}" = "true" ] && [ -f package-lock.json ]; then
+        if grep -E -n "https?://(registry\.npmjs\.org|api\.nuget\.org|pypi\.org|files\.pythonhosted\.org)" package-lock.json; then
+          echo "Public package sources found in package-lock.json. Replace them with an internal mirror/feed."
+          exit 1
+        fi
+      fi
+    displayName: "Block public package sources"
   - bash: npm ci
     displayName: "npm ci"
-  - bash: gulp
+  - bash: npx gulp
     displayName: "gulp default"
   - bash: "npm run test --verbose"
     displayName: "Run unit tests"

--- a/.ci/master-pipeline.yml
+++ b/.ci/master-pipeline.yml
@@ -2,6 +2,7 @@ trigger:
   - master
 variables:
   Codeql.Enabled: true
+  NpmRegistry: $(NPM_REGISTRY_URL)
 pr:
   - none
 resources:
@@ -32,6 +33,9 @@ extends:
               - checkout: self
                 clean: true
               - template: /.ci/common-validation.yml@self
+                parameters:
+                  npmRegistry: $(NpmRegistry)
+                  enforceNetworkIsolation: true
           - job: Windows
             pool:
               name: VSWebDiag1ESPipelinePool
@@ -48,6 +52,9 @@ extends:
               - checkout: self
                 clean: true
               - template: /.ci/common-validation.yml@self
+                parameters:
+                  npmRegistry: $(NpmRegistry)
+                  enforceNetworkIsolation: true
               - task: Npm@1
                 displayName: "npm pack"
                 inputs:
@@ -77,3 +84,6 @@ extends:
               - checkout: self
                 clean: true
               - template: /.ci/common-validation.yml@self
+                parameters:
+                  npmRegistry: $(NpmRegistry)
+                  enforceNetworkIsolation: true

--- a/.ci/master-pipeline.yml
+++ b/.ci/master-pipeline.yml
@@ -18,6 +18,8 @@ extends:
       name: VSWebDiag1ESPipelinePool
       image: VSWebDiag_1ESImage_Windows
       os: windows
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     customBuildTags:
       - ES365AIMigrationTooling
     stages:

--- a/.ci/pr-pipeline.yml
+++ b/.ci/pr-pipeline.yml
@@ -5,6 +5,9 @@ pr:
 trigger:
   - none
 
+variables:
+  NpmRegistry: $(NPM_REGISTRY_URL)
+
 jobs:
   - job: Linux
     pool:
@@ -14,6 +17,9 @@ jobs:
       - checkout: self
         clean: true
       - template: common-validation.yml
+        parameters:
+          npmRegistry: $(NpmRegistry)
+          enforceNetworkIsolation: true
 
   - job: Windows
     pool:
@@ -23,6 +29,9 @@ jobs:
       - checkout: self
         clean: true
       - template: common-validation.yml
+        parameters:
+          npmRegistry: $(NpmRegistry)
+          enforceNetworkIsolation: true
 
   - job: macOS
     pool:
@@ -32,3 +41,6 @@ jobs:
       - checkout: self
         clean: true
       - template: common-validation.yml
+        parameters:
+          npmRegistry: $(NpmRegistry)
+          enforceNetworkIsolation: true


### PR DESCRIPTION
- Remove global gulp installation, use npx gulp instead
- Add mandatory private npm registry configuration validation
- Scan package-lock.json to block public sources (npmjs, nuget, pypi)
- Wire network isolation parameters through PR and master pipelines
- Prevent accidental fallback to public npm registry