### PR TITLE
Fix security vulnerability: bump js-yaml overrides to 3.15.0 and 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2628,6 +2628,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2706,6 +2717,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/eslint/node_modules/path-exists": {
@@ -3906,9 +3932,9 @@
       }
     },
     "node_modules/gulp-eslint/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4781,10 +4807,20 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8290,7 +8326,7 @@
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -9969,7 +10005,7 @@
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^3.15.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -9982,6 +10018,16 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -10033,6 +10079,17 @@
           "peer": true,
           "requires": {
             "type-fest": "^0.20.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "path-exists": {
@@ -10858,7 +10915,7 @@
             "imurmurhash": "^0.1.4",
             "inquirer": "^7.0.0",
             "is-glob": "^4.0.0",
-            "js-yaml": "^3.13.1",
+            "js-yaml": "^3.15.0",
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "levn": "^0.3.0",
             "lodash": "^4.17.14",
@@ -10969,9 +11026,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -11597,9 +11654,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -11926,7 +11983,7 @@
         "find-up": "^5.0.0",
         "glob": "^8.1.0",
         "he": "^1.2.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "log-symbols": "^4.1.0",
         "minimatch": "^5.1.6",
         "ms": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
   "overrides": {
     "@babel/core": "^7.28.6",
     "flatted": "^3.4.2",
+    "js-yaml": "^4.2.0",
+    "gulp-eslint": {
+      "js-yaml": "^3.15.0"
+    },
     "serialize-javascript": "^7.0.5",
     "tmp": "^0.2.6"
   },


### PR DESCRIPTION
## Summary

Fixes two open Dependabot alerts for `js-yaml` quadratic-complexity DoS vulnerability (merge key handling via repeated aliases):

- Alert #115: `js-yaml < 3.15.0` nested under `gulp-eslint` (3.14.2 → 3.15.0)
- Alert #114: `js-yaml >= 4.0.0, <= 4.1.1` top-level (4.1.1 → 4.3.0)

Adds two npm `overrides` entries:
- `"js-yaml": "^4.2.0"` — upgrades the top-level instance used by `mocha` / `eslint`
- `"gulp-eslint" > "js-yaml": "^3.15.0"` — pins the nested instance to 3.x (js-yaml 3.x→4.x has breaking API changes, so forcing 4.x here would break `gulp-eslint`)

## Test Plan

- [x] `node_modules/js-yaml` resolves to 4.3.0 (≥ 4.2.0)
- [x] `node_modules/gulp-eslint/node_modules/js-yaml` resolves to 3.15.0 (≥ 3.15.0)
- [ ] `npm test` passes with no regressions

Closes #607